### PR TITLE
Handle missing volume column in cached price data

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1186,7 +1186,14 @@ def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tu
     if cache_path.exists():
         try:
             combined = pd.read_parquet(cache_path)
-            return combined["Close"], combined["Volume"]
+            if isinstance(combined.columns, pd.MultiIndex):
+                needed = {"Close", "Volume"}
+                have = set(combined.columns.get_level_values(0))
+                if needed.issubset(have):
+                    return combined["Close"], combined["Volume"]
+            else:
+                if {"Close", "Volume"}.issubset(combined.columns):
+                    return combined["Close"], combined["Volume"]
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- Safeguard `fetch_price_volume` against caches missing the Volume column before returning cached results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6841d5b3c8327b07f8e733794e1be