### PR TITLE
Use historical NASDAQ-100 constituents and date-aware backtests

### DIFF
--- a/tests/test_constituent_membership.py
+++ b/tests/test_constituent_membership.py
@@ -1,0 +1,47 @@
+import types
+import pandas as pd
+import pytest
+
+import strategy_core as sc
+
+
+def test_momentum_respects_constituents():
+    idx = pd.to_datetime(["2020-01-31", "2020-02-29", "2020-03-31", "2020-04-30"])
+    prices = pd.DataFrame({
+        "A": [100, 110, 121, 133.1],
+        "B": [100, 200, 400, 800],
+    }, index=idx)
+
+    members = {
+        pd.Timestamp("2020-03-31"): ["A"],
+        pd.Timestamp("2020-04-30"): ["A", "B"],
+    }
+
+    def get_members(dt):
+        return members.get(dt, ["A", "B"])
+
+    rets, _ = sc.run_backtest_momentum(
+        prices,
+        lookback_m=1,
+        top_n=1,
+        cap=1.0,
+        get_constituents=get_members,
+    )
+
+    assert rets.loc[pd.Timestamp("2020-03-31")] == pytest.approx(0.1)
+
+
+def test_constituent_cache(monkeypatch):
+    sc._NDX_CONSTITUENT_CACHE.clear()
+    calls = []
+
+    def fake_get(url, params=None, **kwargs):
+        calls.append(params.get("date"))
+        text = "ticker\nAAPL\nMSFT\n"
+        return types.SimpleNamespace(text=text, status_code=200, raise_for_status=lambda: None)
+
+    monkeypatch.setattr(sc.requests, "get", fake_get)
+    first = sc.get_nasdaq_100_plus_tickers(as_of="2024-01-01")
+    second = sc.get_nasdaq_100_plus_tickers(as_of="2024-01-01")
+    assert first == second == ["AAPL", "MSFT"]
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- Switch NASDAQ-100 universe to Nasdaq Data Link for historical constituent lookup with per-date caching
- Allow momentum, predictive, and mean-reversion backtests to filter by index membership each period and expose membership callback in hybrid runner
- Add tests validating constituent caching and period-specific membership filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6868ac6a0832797c6542f56185b5c