### PR TITLE
Add gradient boosting predictive model

### DIFF
--- a/predictive_models.py
+++ b/predictive_models.py
@@ -1,0 +1,171 @@
+"""Machine learning utilities for price prediction.
+
+This module implements a light-weight gradient boosting model that operates on
+factor data (e.g., momentum, volatility, quality).  The implementation avoids
+third party dependencies to keep the project self-contained.  Features are
+standardised before modelling and a simple time-series cross‑validation loop is
+executed for each ticker.
+
+The main entry point :func:`predict_next_returns` fits a model per ticker and
+returns a forecast for the next period return.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class _StandardScaler:
+    """Minimal standard scaler.
+
+    Stores column-wise means and standard deviations and applies a standard
+    z-score transformation.  A value of ``1`` is used whenever the standard
+    deviation is ``0`` to avoid division errors.
+    """
+
+    mean_: np.ndarray | None = None
+    scale_: np.ndarray | None = None
+
+    def fit(self, X: np.ndarray) -> "_StandardScaler":
+        self.mean_ = np.nanmean(X, axis=0)
+        self.scale_ = np.nanstd(X, axis=0)
+        self.scale_[self.scale_ == 0] = 1.0
+        return self
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        if self.mean_ is None or self.scale_ is None:
+            raise ValueError("Scaler has not been fitted.")
+        return (X - self.mean_) / self.scale_
+
+    def fit_transform(self, X: np.ndarray) -> np.ndarray:
+        return self.fit(X).transform(X)
+
+
+class _GradientBoostingLinear:
+    """Simple gradient boosting using linear base learners.
+
+    The model iteratively fits linear regressions to the residuals of the
+    previous stage.  Although significantly simpler than tree-based gradient
+    boosting, it captures non-linear interactions through the boosting
+    mechanism and is sufficient for small feature sets.
+    """
+
+    def __init__(self, n_estimators: int = 100, learning_rate: float = 0.1):
+        self.n_estimators = n_estimators
+        self.learning_rate = learning_rate
+        self.coefs_: list[np.ndarray] = []
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> "_GradientBoostingLinear":
+        X = np.asarray(X, dtype=float)
+        y = np.asarray(y, dtype=float)
+        pred = np.zeros_like(y)
+        self.coefs_ = []
+        for _ in range(self.n_estimators):
+            residual = y - pred
+            coef, *_ = np.linalg.lstsq(X, residual, rcond=None)
+            self.coefs_.append(coef)
+            pred += self.learning_rate * X.dot(coef)
+        return self
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        X = np.asarray(X, dtype=float)
+        pred = np.zeros(X.shape[0])
+        for coef in self.coefs_:
+            pred += self.learning_rate * X.dot(coef)
+        return pred
+
+
+def _time_series_cv_score(
+    X: np.ndarray, y: np.ndarray, n_splits: int, n_estimators: int, learning_rate: float
+) -> float:
+    """Run a simple rolling-origin cross‑validation and return mean MSE."""
+
+    n_samples = len(X)
+    if n_samples < n_splits + 2:
+        return float("nan")
+
+    fold_size = n_samples // (n_splits + 1)
+    scores = []
+    for i in range(n_splits):
+        train_end = fold_size * (i + 1)
+        test_end = fold_size * (i + 2)
+        X_train, y_train = X[:train_end], y[:train_end]
+        X_test, y_test = X[train_end:test_end], y[train_end:test_end]
+
+        scaler = _StandardScaler()
+        X_train_s = scaler.fit_transform(X_train)
+        X_test_s = scaler.transform(X_test)
+
+        model = _GradientBoostingLinear(n_estimators=n_estimators, learning_rate=learning_rate)
+        model.fit(X_train_s, y_train)
+        pred = model.predict(X_test_s)
+        scores.append(np.mean((pred - y_test) ** 2))
+
+    return float(np.mean(scores)) if scores else float("nan")
+
+
+def predict_next_returns(
+    prices: pd.DataFrame,
+    features: pd.DataFrame,
+    n_splits: int = 3,
+    n_estimators: int = 100,
+    learning_rate: float = 0.1,
+) -> pd.Series:
+    """Forecast next-period returns for each ticker.
+
+    Parameters
+    ----------
+    prices : DataFrame
+        Historical prices indexed by date and with tickers as columns.
+    features : DataFrame
+        MultiIndex columns (ticker, factor).  Each inner DataFrame contains
+        factor values aligned to ``prices``.
+    n_splits : int, optional
+        Number of cross‑validation splits for the rolling-origin evaluation.
+    n_estimators, learning_rate : optional
+        Gradient boosting hyper-parameters.
+
+    Returns
+    -------
+    Series
+        Per-ticker forecast of the next period return.  Tickers with
+        insufficient data will be omitted.
+    """
+
+    if not isinstance(features.columns, pd.MultiIndex):
+        raise ValueError("features must have MultiIndex columns (ticker, factor)")
+
+    # Next-period returns serve as the prediction target.
+    future_rets = prices.pct_change().shift(-1)
+    preds: Dict[str, float] = {}
+
+    for ticker in prices.columns:
+        if ticker not in features.columns.get_level_values(0):
+            continue
+
+        feat = features[ticker]
+        targ = future_rets[ticker].reindex(feat.index)
+        data = pd.concat([feat, targ.rename("target")], axis=1).dropna()
+        if len(data) < max(3, n_splits + 2):
+            continue
+
+        X = data.drop(columns=["target"]).to_numpy(dtype=float)
+        y = data["target"].to_numpy(dtype=float)
+        latest_feat = feat.iloc[[-1]].to_numpy(dtype=float)
+
+        # Cross-validation (errors ignored; used for estimation only)
+        _time_series_cv_score(X, y, n_splits, n_estimators, learning_rate)
+
+        scaler = _StandardScaler()
+        X_s = scaler.fit_transform(X)
+        latest_s = scaler.transform(latest_feat)
+
+        model = _GradientBoostingLinear(n_estimators=n_estimators, learning_rate=learning_rate)
+        model.fit(X_s, y)
+        preds[ticker] = float(model.predict(latest_s)[0])
+
+    return pd.Series(preds)

--- a/tests/test_predictive_models.py
+++ b/tests/test_predictive_models.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pandas as pd
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import predictive_models as pm
+
+
+def _make_data(n=30):
+    idx = pd.date_range('2024-01-01', periods=n, freq='D')
+    prices = pd.DataFrame({
+        'AAA': 100 * (1 + 0.001) ** np.arange(n),
+        'BBB': 100 * (1 - 0.001) ** np.arange(n)
+    }, index=idx)
+    rets = prices.pct_change()
+    factors = {}
+    for t in prices.columns:
+        momentum = rets[t].rolling(3).mean()
+        volatility = rets[t].rolling(5).std()
+        quality = 1 / prices[t].rolling(5).mean()
+        factors[t] = pd.concat(
+            [momentum.rename('momentum'),
+             volatility.rename('volatility'),
+             quality.rename('quality')], axis=1
+        )
+    features = pd.concat(factors, axis=1)
+    return prices, features
+
+
+def test_predict_next_returns_outputs_series():
+    prices, features = _make_data()
+    preds = pm.predict_next_returns(prices, features)
+    assert set(preds.index) == {'AAA', 'BBB'}
+    assert preds.notna().all()


### PR DESCRIPTION
## Summary
- Implement lightweight gradient boosting module with internal standardization and time-series cross-validation
- Add `predict_next_returns` to produce per-ticker forecasts from factor features
- Test predictive model on synthetic momentum/volatility/quality factors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c687c8526c8327aaed3e44c1fdd9f1