### PR TITLE
Fix turnover and weight capping

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,7 +64,12 @@ mc_seed_input = st.sidebar.text_input(
     value=str(st.session_state["mc_seed"]),
     help="Controls the random seed for Monte Carlo projections",
 )
-st.session_state["mc_seed"] = int(mc_seed_input) if mc_seed_input.strip() else None
+raw = mc_seed_input.strip()
+try:
+    st.session_state["mc_seed"] = int(raw) if raw else None
+except ValueError:
+    st.session_state["mc_seed"] = None
+    st.sidebar.warning("Monte Carlo seed must be an integer (blank for random).")
 
 # Initialize parameters from presets or prior assessment
 st.session_state.setdefault("stickiness_days", preset.get("stability_days", 7))
@@ -338,11 +343,17 @@ with tab2:
             sectors_map = backend.get_enhanced_sector_map(
                 list(weights.index), base_map=base_map
             )
+            group_caps = backend.build_group_caps(sectors_map)
             violations = backend.check_constraint_violations(
                 weights,
                 sectors_map,
-                name_cap=float(st.session_state.get("name_cap", preset.get("mom_cap", 0.25))),
-                sector_cap=float(st.session_state.get("sector_cap", preset.get("sector_cap", 0.30))),
+                name_cap=float(
+                    st.session_state.get("name_cap", preset.get("mom_cap", 0.25))
+                ),
+                sector_cap=float(
+                    st.session_state.get("sector_cap", preset.get("sector_cap", 0.30))
+                ),
+                group_caps=group_caps,
             )
 
             max_w = weights.max()

--- a/backend.py
+++ b/backend.py
@@ -147,10 +147,7 @@ def clean_extreme_moves(
 
     if total_corrections > 0:
         msg = f"🧹 Data cleaning: Fixed {total_corrections} extreme price moves across all stocks"
-        if info:
-            info(msg)
-        else:
-            logging.info(msg)
+        (info or logging.info)(msg)
 
     return cleaned_df, replaced_mask
 
@@ -203,10 +200,7 @@ def fill_missing_data(
 
     if total_filled > 0:
         msg = f"🔧 Data filling: Filled {total_filled} missing data points with interpolation"
-        if info:
-            info(msg)
-        else:
-            logging.info(msg)
+        (info or logging.info)(msg)
 
     return filled_df, imputed_mask
 

--- a/backend.py
+++ b/backend.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
 import optimizer
 import strategy_core
-from strategy_core import HybridConfig, cap_weights as sc_cap_weights  # alias to avoid shadowing
+from strategy_core import HybridConfig
 
 warnings.filterwarnings("ignore")
 

--- a/backend.py
+++ b/backend.py
@@ -1,6 +1,6 @@
 # backend.py — Enhanced Hybrid Top150 / Composite Rank / Sector Caps / Stickiness / ISA lock
 import os, io, warnings, json, hashlib
-from typing import Optional, Tuple, Dict, List, Any
+from typing import Optional, Tuple, Dict, List, Any, Callable
 import numpy as np
 import pandas as pd
 import yfinance as yf
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
 import optimizer
 import strategy_core
-from strategy_core import HybridConfig
+from strategy_core import HybridConfig, cap_weights as sc_cap_weights  # alias to avoid shadowing
 
 warnings.filterwarnings("ignore")
 
@@ -24,7 +24,15 @@ warnings.filterwarnings("ignore")
 GIST_ID = st.secrets.get("GIST_ID")
 GITHUB_TOKEN = st.secrets.get("GITHUB_TOKEN")
 GIST_API_URL = f"https://api.github.com/gists/{GIST_ID}" if GIST_ID else None
-HEADERS = {"Authorization": f"Bearer {GITHUB_TOKEN}"} if GITHUB_TOKEN else {}
+HEADERS = (
+    {
+        "Authorization": f"token {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "isa-dynamic/1.0",
+    }
+    if GITHUB_TOKEN
+    else {}
+)
 
 GIST_PORTF_FILE = "portfolio.json"
 LIVE_PERF_FILE  = "live_perf.csv"
@@ -75,6 +83,7 @@ def clean_extreme_moves(
     max_daily_move: float = 0.30,
     min_price: float = 1.0,
     zscore_threshold: float = 5.0,
+    info: Callable[[str], None] | None = None,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Clean extreme price moves that are likely data errors.
 
@@ -98,11 +107,12 @@ def clean_extreme_moves(
         # Remove prices below minimum (likely stock splits not handled)
         low_price_mask = series < min_price
         if low_price_mask.any():
-            series = series.where(~low_price_mask).ffill()
+            series = series.where(~low_price_mask)
+            series = series.ffill().bfill()
             replaced_mask.loc[low_price_mask, column] = True
             total_corrections += int(low_price_mask.sum())
 
-        while True:
+        for _ in range(50):
             daily_returns = series.pct_change().abs()
             log_returns = np.log(series).diff()
             rolling_mean = log_returns.shift(1).rolling(window=20, min_periods=1).mean()
@@ -136,14 +146,18 @@ def clean_extreme_moves(
         cleaned_df[column] = series
 
     if total_corrections > 0:
-        st.info(
-            f"🧹 Data cleaning: Fixed {total_corrections} extreme price moves across all stocks"
-        )
+        msg = f"🧹 Data cleaning: Fixed {total_corrections} extreme price moves across all stocks"
+        if info:
+            info(msg)
+        else:
+            logging.info(msg)
 
     return cleaned_df, replaced_mask
 
 def fill_missing_data(
-    prices_df: pd.DataFrame, max_gap_days: int = 5
+    prices_df: pd.DataFrame,
+    max_gap_days: int = 5,
+    info: Callable[[str], None] | None = None,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Fill missing data gaps with interpolation limited to each gap.
 
@@ -178,13 +192,9 @@ def fill_missing_data(
                 start_idx = series.index.get_loc(gap_indices[0])
                 end_idx = series.index.get_loc(gap_indices[-1])
 
-                prev_price = series.iloc[start_idx - 1] if start_idx > 0 else np.nan
-                next_price = series.iloc[end_idx + 1] if end_idx < len(series) - 1 else np.nan
-
-                if pd.notna(prev_price):
-                    series.loc[gap_indices] = prev_price
-                if series.loc[gap_indices].isna().any() and pd.notna(next_price):
-                    series.loc[gap_indices] = next_price
+                seg = series.iloc[max(0, start_idx - 1) : min(len(series), end_idx + 2)]
+                seg = seg.interpolate(method="linear", limit_direction="both")
+                series.loc[gap_indices] = seg.loc[gap_indices]
 
                 imputed_mask.loc[gap_indices, column] = True
                 total_filled += len(gap_indices)
@@ -192,14 +202,17 @@ def fill_missing_data(
         filled_df[column] = series
 
     if total_filled > 0:
-        st.info(
-            f"🔧 Data filling: Filled {total_filled} missing data points with interpolation"
-        )
+        msg = f"🔧 Data filling: Filled {total_filled} missing data points with interpolation"
+        if info:
+            info(msg)
+        else:
+            logging.info(msg)
 
     return filled_df, imputed_mask
 
 def validate_and_clean_market_data(
     prices_df: pd.DataFrame,
+    info: Callable[[str], None] | None = None,
 ) -> Tuple[pd.DataFrame, List[str], pd.DataFrame]:
     """Comprehensive data validation and cleaning pipeline.
 
@@ -216,11 +229,11 @@ def validate_and_clean_market_data(
 
     # Step 1: Clean extreme moves
     cleaned_df, replaced_mask = clean_extreme_moves(
-        prices_df, max_daily_move=0.25, min_price=0.50
+        prices_df, max_daily_move=0.25, min_price=0.50, info=info
     )
 
     # Step 2: Fill missing data gaps
-    filled_df, fill_mask = fill_missing_data(cleaned_df, max_gap_days=3)
+    filled_df, fill_mask = fill_missing_data(cleaned_df, max_gap_days=3, info=info)
 
     imputed_mask = replaced_mask | fill_mask
 
@@ -386,7 +399,6 @@ def enforce_caps_iteratively(
     return w
 
 # --- Enhanced sector bucketing -----------------------------------------------
-from typing import Dict, List, Optional
 
 def get_enhanced_sector_map(tickers: list[str], base_map: dict[str, str] | None = None) -> dict[str, str]:
     """
@@ -404,7 +416,7 @@ def get_enhanced_sector_map(tickers: list[str], base_map: dict[str, str] | None 
         "CRWD","ZS","FTNT","PANW","OKTA","S","TENB","NET"
     }
     sec_data_ai = {
-        "PLTR","SNOW","MDB","DDOG","NRTX","AI"  # keep PLTR here
+        "PLTR","SNOW","MDB","DDOG","AI"  # keep PLTR here
     }
     sec_adtech = {"APP","TTD"}
     sec_collab = {"ZM","TEAM"}
@@ -534,8 +546,11 @@ def risk_parity_weights(prices: pd.DataFrame, tickers: List[str], lookback: int 
 # =========================
 # NEW: Signal Decay Modeling
 # =========================
-def apply_signal_decay(momentum_scores: pd.Series, signal_age_days: Any = 0,
-                      half_life: int = 45) -> pd.Series:
+def apply_signal_decay(
+    momentum_scores: pd.Series,
+    signal_age_days: int | float | pd.Series | dict[str, int] = 0,
+    half_life: int = 45,
+) -> pd.Series:
     """Apply exponential decay to momentum signals based on age
 
     Parameters
@@ -806,20 +821,26 @@ def apply_dynamic_drawdown_scaling(monthly_returns: pd.Series,
 # =========================
 # NEW: Portfolio Correlation Monitoring
 # =========================
-def calculate_portfolio_correlation_to_market(portfolio_returns: pd.Series,
-                                            market_returns: pd.Series = None) -> float:
+def calculate_portfolio_correlation_to_market(
+    portfolio_returns: pd.Series,
+    market_returns: pd.Series = None,
+) -> float:
     """Calculate correlation between portfolio and benchmark.
 
-    Both ``portfolio_returns`` and ``market_returns`` should contain daily (or
-    higher frequency) returns. The series are resampled to monthly returns
-    before computing correlation to reduce high‑frequency noise.
+    Both ``portfolio_returns`` and ``market_returns`` may be at any frequency;
+    the series are resampled to monthly returns before computing correlation to
+    reduce high‑frequency noise.
     """
     if market_returns is None:
         # Fetch QQQ data for correlation
         try:
             end_date = datetime.now().strftime('%Y-%m-%d')
             start_date = (datetime.now() - relativedelta(months=6)).strftime('%Y-%m-%d')
-            qqq_data = yf.download('QQQ', start=start_date, end=end_date, auto_adjust=True, progress=False)['Close']
+            qqq_data = _yf_download(
+                'QQQ',
+                start=start_date,
+                end=end_date,
+            )['Close']
             market_returns = qqq_data.pct_change().dropna()
         except:
             return np.nan
@@ -887,6 +908,17 @@ def _chunk_tickers(tickers: List[str], size: int = _YF_BATCH_SIZE):
     for i in range(0, len(tickers), size):
         yield tickers[i : i + size]
 
+
+def _yf_download(tickers, **kwargs):
+    params = dict(auto_adjust=True, progress=False, group_by="column", timeout=10)
+    params.update(kwargs)
+    try:
+        return yf.download(tickers, **params)
+    except TypeError:
+        params.pop("group_by", None)
+        params.pop("timeout", None)
+        return yf.download(tickers, **params)
+
 # =========================
 # Universe builders & sectors (Enhanced with validation)
 # =========================
@@ -895,7 +927,7 @@ def fetch_sp500_constituents() -> List[str]:
     """Get current S&P 500 tickers with fallback to static list."""
     try:
         url = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
-        resp = requests.get(url, headers={'User-Agent': 'Mozilla/5.0'})
+        resp = requests.get(url, headers={'User-Agent': 'Mozilla/5.0'}, timeout=10)
         tables = pd.read_html(StringIO(resp.text))
         df = next(
             t for t in tables
@@ -1032,7 +1064,8 @@ def get_nasdaq_100_plus_tickers() -> List[str]:
     try:
         resp = requests.get(
             "https://en.wikipedia.org/wiki/Nasdaq-100",
-            headers={'User-Agent': 'Mozilla/5.0'}
+            headers={'User-Agent': 'Mozilla/5.0'},
+            timeout=10,
         )
         tables = pd.read_html(StringIO(resp.text))
         df = next(
@@ -1141,9 +1174,11 @@ def fetch_market_data(tickers: List[str], start_date: str, end_date: str) -> pd.
         fetch_start = (pd.to_datetime(start_date) - pd.DateOffset(months=14)).strftime("%Y-%m-%d")
         frames: List[pd.DataFrame] = []
         for batch in _chunk_tickers(tickers):
-            df = yf.download(batch, start=fetch_start, end=end_date, auto_adjust=True, progress=False)[
-                "Close"
-            ]
+            df = _yf_download(
+                batch,
+                start=fetch_start,
+                end=end_date,
+            )["Close"]
             if isinstance(df, pd.Series):
                 df = df.to_frame()
                 df.columns = [batch[0]]
@@ -1157,12 +1192,12 @@ def fetch_market_data(tickers: List[str], start_date: str, end_date: str) -> pd.
 
         # Enhanced data cleaning pipeline
         if not result.empty:
-            cleaned_result, cleaning_alerts, _ = validate_and_clean_market_data(result)
+            cleaned_result, cleaning_alerts, _ = validate_and_clean_market_data(result, info=logging.info)
 
             # Show cleaning summary
             if cleaning_alerts:
                 for alert in cleaning_alerts[:2]:  # Show top 2 cleaning actions
-                    st.info(f"🧹 Data cleaning: {alert}")
+                    logging.info("Data cleaning: %s", alert)
 
             try:
                 cleaned_result.to_parquet(cache_path)
@@ -1202,9 +1237,11 @@ def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tu
         close_frames: List[pd.DataFrame] = []
         vol_frames: List[pd.DataFrame] = []
         for batch in _chunk_tickers(tickers):
-            df = yf.download(batch, start=fetch_start, end=end_date, auto_adjust=True, progress=False)[
-                ["Close", "Volume"]
-            ]
+            df = _yf_download(
+                batch,
+                start=fetch_start,
+                end=end_date,
+            )[["Close", "Volume"]]
             if isinstance(df, pd.Series):
                 df = df.to_frame()
             if isinstance(df.columns, pd.MultiIndex):
@@ -1231,7 +1268,7 @@ def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tu
 
         # Enhanced data cleaning for prices
         if not close.empty:
-            cleaned_close, close_alerts, _ = validate_and_clean_market_data(close)
+            cleaned_close, close_alerts, _ = validate_and_clean_market_data(close, info=logging.info)
 
             # Clean volume data (less aggressive)
             vol_aligned = vol.reindex_like(cleaned_close).fillna(0)
@@ -1243,7 +1280,7 @@ def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tu
 
             if close_alerts:
                 for alert in close_alerts[:1]:  # Show top cleaning action
-                    st.info(f"🧹 Price/Volume cleaning: {alert}")
+                    logging.info("Price/Volume cleaning: %s", alert)
 
             try:
                 pd.concat({"Close": cleaned_close, "Volume": vol_aligned}, axis=1).to_parquet(cache_path)
@@ -1271,7 +1308,7 @@ def save_portfolio_to_gist(portfolio_df: pd.DataFrame) -> None:
     try:
         json_content = portfolio_df.to_json(orient="index")
         payload = {"files": {GIST_PORTF_FILE: {"content": json_content}}}
-        resp = requests.patch(GIST_API_URL, headers=HEADERS, json=payload)
+        resp = requests.patch(GIST_API_URL, headers=HEADERS, json=payload, timeout=10)
         resp.raise_for_status()
         st.sidebar.success("✅ Successfully saved portfolio to Gist.")
     except Exception as e:
@@ -1333,7 +1370,7 @@ def load_previous_portfolio() -> Optional[pd.DataFrame]:
     # Gist first
     if GIST_API_URL and GITHUB_TOKEN:
         try:
-            resp = requests.get(GIST_API_URL, headers=HEADERS)
+            resp = requests.get(GIST_API_URL, headers=HEADERS, timeout=10)
             resp.raise_for_status()
             files = resp.json().get("files", {})
             content = files.get(GIST_PORTF_FILE, {}).get("content", "")
@@ -1744,20 +1781,17 @@ def fetch_fundamental_metrics(tickers: List[str]) -> pd.DataFrame:
         leverage = np.nan
         try:
             tkr = yf.Ticker(t)
-            fi = tkr.fast_info
-            profitability = fi.get("returnOnAssets") or fi.get("profitMargins")
-            leverage = fi.get("debtToEquity")
-            info = {}
-            if profitability is None or leverage is None:
-                info = _safe_get_info(tkr)
-            if profitability is None:
-                profitability = info.get("returnOnAssets") or info.get("profitMargins")
+            fi = tkr.fast_info or {}
+            info = _safe_get_info(tkr)
+            profitability = info.get("returnOnAssets") or info.get("profitMargins")
+            leverage = info.get("debtToEquity")
             if leverage is None:
-                leverage = info.get("debtToEquity")
+                leverage = fi.get("debtToEquity")
+            if profitability is None:
+                profitability = fi.get("returnOnAssets") or fi.get("profitMargins")
             if leverage is not None and leverage > 10:
-                # many providers return percentage values
                 leverage = leverage / 100.0
-        except Exception as e:
+        except Exception:
             logging.warning("E01 fundamental data fetch failed", exc_info=True)
         rows.append({"Ticker": t, "profitability": profitability, "leverage": leverage})
     return pd.DataFrame(rows).set_index("Ticker")
@@ -1788,13 +1822,13 @@ def _build_isa_weights_fixed(
     sectors_map: Dict[str, str],
     use_enhanced_features: bool = True,
 ) -> pd.Series:
-    """Apply position sizing + hierarchical caps (name/sector + Software sub-caps) to the final combined portfolio.
+    """Apply position sizing + hierarchical caps (name/sector + Software sub-caps)
+    to the final combined portfolio.
 
-    When ``use_enhanced_features`` is True, the raw sleeve weights are further
-    adjusted using risk-parity weights and volatility-aware name caps before the
-    standard hierarchical cap enforcement. Cap trimming doesn't redistribute
-    weight, so any residual cash is scaled back to full exposure at the end of
-    this function.
+    When ``use_enhanced_features`` is True, the raw sleeve weights are blended
+    with risk-parity weights and adjusted by volatility-aware name caps before
+    hierarchical cap enforcement. Cap trimming does **not** redistribute weight;
+    any residual cash is returned to the caller to handle separately.
     """
     monthly = daily_close.resample("M").last()
 
@@ -1837,14 +1871,11 @@ def _build_isa_weights_fixed(
         return combined_raw
 
     if use_enhanced_features:
-        # Apply risk parity weighting
-        rp_weights = risk_parity_weights(daily_close, combined_raw.index.tolist())
-        combined_raw = combined_raw.mul(rp_weights, fill_value=0.0)
-        combined_raw = (
-            combined_raw / combined_raw.sum() if combined_raw.sum() > 0 else combined_raw
-        )
+        rp = risk_parity_weights(daily_close, combined_raw.index.tolist())
+        rp = rp / rp.sum() if rp.sum() > 0 else rp
+        lam = 0.4
+        combined_raw = lam * combined_raw + (1 - lam) * (combined_raw.sum() * rp)
 
-        # Volatility-aware name caps prior to hierarchical cap enforcement
         vol_caps = get_volatility_adjusted_caps(
             combined_raw, daily_close, base_cap=preset.get("mom_cap", 0.25)
         )
@@ -1867,11 +1898,7 @@ def _build_isa_weights_fixed(
         group_caps=group_caps,             # <- IMPORTANT: turns on the sub-caps
     )
 
-    if final_weights.empty or final_weights.sum() <= 0:
-        return final_weights
-
-    # Keep weights summing to 1 across equities (cash is whatever is left at the portfolio level)
-    return final_weights / final_weights.sum() if final_weights.sum() > 0 else final_weights
+    return final_weights
 
 def check_constraint_violations(
     weights: pd.Series,
@@ -2050,9 +2077,19 @@ def generate_live_portfolio_isa_monthly(
             held_scores = mom_scores.reindex(prev_w.index).fillna(0.0)
             health = float((held_scores * prev_w).sum() / max(top_score, 1e-9))
             if health >= params["trigger"]:
-                prev_w = enforce_caps_iteratively(prev_w, sectors_map, mom_cap, sector_cap)
+                enhanced_map = get_enhanced_sector_map(list(prev_w.index), base_map=sectors_map)
+                group_caps = build_group_caps(enhanced_map)
+                prev_w = enforce_caps_iteratively(
+                    prev_w,
+                    enhanced_map,
+                    mom_cap,
+                    sector_cap,
+                    group_caps=group_caps,
+                )
                 prev_w = prev_w / prev_w.sum()
-                violations = check_constraint_violations(prev_w, sectors_map, mom_cap, sector_cap)
+                violations = check_constraint_violations(
+                    prev_w, sectors_map, mom_cap, sector_cap, group_caps=group_caps
+                )
                 if not violations:
                     decision = f"Health {health:.2f} ≥ trigger {params['trigger']:.2f} — holding existing portfolio."
                     disp, raw = _format_display(prev_w)
@@ -2381,8 +2418,10 @@ def get_benchmark_series(ticker: str, start: str, end: str) -> pd.Series:
     """
     for attempt in range(2):
         try:
-            data = yf.download(
-                ticker, start=start, end=end, auto_adjust=True, progress=False
+            data = _yf_download(
+                ticker,
+                start=start,
+                end=end,
             )
             try:
                 px = data["Close"]
@@ -2494,8 +2533,11 @@ def select_optimal_universe(as_of: date | None = None) -> str:
     # Proxy ETFs for each universe
     etfs = {"NASDAQ100+": "QQQ", "S&P500 (All)": "SPY", "Hybrid Top150": "SPY"}
     try:
-        data = yf.download(list(set(etfs.values())), start=start, end=end,
-                            auto_adjust=True, progress=False)["Close"]
+        data = _yf_download(
+            list(set(etfs.values())),
+            start=start,
+            end=end,
+        )["Close"]
         if isinstance(data, pd.Series):
             data = data.to_frame()
     except Exception:
@@ -2625,7 +2667,7 @@ def assess_market_conditions(as_of: date | None = None) -> Dict[str, Any]:
 def load_assess_log() -> pd.DataFrame:
     if GIST_API_URL and GITHUB_TOKEN:
         try:
-            resp = requests.get(GIST_API_URL, headers=HEADERS)
+            resp = requests.get(GIST_API_URL, headers=HEADERS, timeout=10)
             resp.raise_for_status()
             files = resp.json().get("files", {})
             content = files.get(ASSESS_LOG_FILE, {}).get("content", "")
@@ -2643,7 +2685,7 @@ def save_assess_log(df: pd.DataFrame) -> None:
     try:
         csv_str = df.to_csv(index=False)
         payload = {"files": {ASSESS_LOG_FILE: {"content": csv_str}}}
-        resp = requests.patch(GIST_API_URL, headers=HEADERS, json=payload)
+        resp = requests.patch(GIST_API_URL, headers=HEADERS, json=payload, timeout=10)
         resp.raise_for_status()
     except Exception as e:
         st.sidebar.warning(f"Could not save assessment log: {e}")
@@ -2855,7 +2897,7 @@ def diagnose_strategy_issues(current_returns: pd.Series,
 def load_live_perf() -> pd.DataFrame:
     if GIST_API_URL and GITHUB_TOKEN:
         try:
-            resp = requests.get(GIST_API_URL, headers=HEADERS)
+            resp = requests.get(GIST_API_URL, headers=HEADERS, timeout=10)
             resp.raise_for_status()
             files = resp.json().get("files", {})
             content = files.get(LIVE_PERF_FILE, {}).get("content", "")
@@ -2874,7 +2916,7 @@ def save_live_perf(df: pd.DataFrame) -> None:
     try:
         csv_str = df.to_csv(index=False)
         payload = {"files": {LIVE_PERF_FILE: {"content": csv_str}}}
-        resp = requests.patch(GIST_API_URL, headers=HEADERS, json=payload)
+        resp = requests.patch(GIST_API_URL, headers=HEADERS, json=payload, timeout=10)
         resp.raise_for_status()
     except Exception as e:
         st.sidebar.warning(f"Could not save live perf: {e}")

--- a/backend.py
+++ b/backend.py
@@ -151,6 +151,7 @@ def clean_extreme_moves(
 
     return cleaned_df, replaced_mask
 
+
 def fill_missing_data(
     prices_df: pd.DataFrame,
     max_gap_days: int = 5,
@@ -203,6 +204,7 @@ def fill_missing_data(
         (info or logging.info)(msg)
 
     return filled_df, imputed_mask
+
 
 def validate_and_clean_market_data(
     prices_df: pd.DataFrame,

--- a/backend.py
+++ b/backend.py
@@ -147,7 +147,10 @@ def clean_extreme_moves(
 
     if total_corrections > 0:
         msg = f"🧹 Data cleaning: Fixed {total_corrections} extreme price moves across all stocks"
-        (info or logging.info)(msg)
+        if info:
+            info(msg)
+        else:
+            logging.info(msg)
 
     return cleaned_df, replaced_mask
 
@@ -201,13 +204,19 @@ def fill_missing_data(
 
     if total_filled > 0:
         msg = f"🔧 Data filling: Filled {total_filled} missing data points with interpolation"
-        (info or logging.info)(msg)
+        if info:
+            info(msg)
+        else:
+            logging.info(msg)
 
     return filled_df, imputed_mask
 
 
 def validate_and_clean_market_data(
     prices_df: pd.DataFrame,
+    max_daily_move: float = 0.25,
+    min_price: float = 0.50,
+    max_gap_days: int = 3,
     info: Callable[[str], None] | None = None,
 ) -> Tuple[pd.DataFrame, List[str], pd.DataFrame]:
     """Comprehensive data validation and cleaning pipeline.
@@ -225,11 +234,13 @@ def validate_and_clean_market_data(
 
     # Step 1: Clean extreme moves
     cleaned_df, replaced_mask = clean_extreme_moves(
-        prices_df, max_daily_move=0.25, min_price=0.50, info=info
+        prices_df, max_daily_move=max_daily_move, min_price=min_price, info=info
     )
 
     # Step 2: Fill missing data gaps
-    filled_df, fill_mask = fill_missing_data(cleaned_df, max_gap_days=3, info=info)
+    filled_df, fill_mask = fill_missing_data(
+        cleaned_df, max_gap_days=max_gap_days, info=info
+    )
 
     imputed_mask = replaced_mask | fill_mask
 

--- a/optimizer.py
+++ b/optimizer.py
@@ -19,7 +19,7 @@ Example
 from __future__ import annotations
 
 import itertools
-from dataclasses import replace
+from dataclasses import replace, fields
 from typing import Dict, Iterable, Tuple
 
 import numpy as np
@@ -28,19 +28,44 @@ import pandas as pd
 from strategy_core import HybridConfig, run_hybrid_backtest
 
 
-def _annualized_sharpe(returns: pd.Series, periods_per_year: int = 12) -> float:
-    """Return annualized Sharpe ratio of a return series.
+def _infer_periods_per_year(index: pd.DatetimeIndex) -> float:
+    """Infer periods/year from a DateTime index."""
+    if index is None or len(index) < 3:
+        return 12.0  # default to monthly
+    try:
+        f = pd.infer_freq(index)
+    except Exception:
+        f = None
+    if f:
+        F = f.upper()
+        if F.startswith(("B", "D")):
+            return 252.0
+        if F.startswith("W"):
+            return 52.0
+        if F.startswith("M"):
+            return 12.0
+        if F.startswith("Q"):
+            return 4.0
+        if F.startswith(("A", "Y")):
+            return 1.0
+    # fallback: median day spacing
+    d = np.median(np.diff(index.view("i8"))) / 1e9 / 86400.0
+    return 252.0 if d <= 2.5 else 52.0 if d <= 9 else 12.0 if d <= 45 else 4.0 if d <= 150 else 1.0
 
-    If the standard deviation is zero or the series is empty, ``-inf`` is
-    returned so such configurations are not selected.
-    """
+
+def _annualized_sharpe(returns: pd.Series, periods_per_year: float | None = None) -> float:
+    """Annualized Sharpe, robust to NaNs/zero-std."""
     if returns is None or len(returns) == 0:
         return float("-inf")
-    std = returns.std()
-    if std == 0 or np.isnan(std):
+    r = pd.Series(returns).dropna()
+    if r.empty:
         return float("-inf")
-    mean = returns.mean()
-    return float(np.sqrt(periods_per_year) * mean / std)
+    ppyr = periods_per_year or _infer_periods_per_year(r.index)
+    std = r.std()
+    if std == 0 or not np.isfinite(std):
+        return float("-inf")
+    mean = r.mean()
+    return float(np.sqrt(ppyr) * mean / std)
 
 
 def grid_search_hybrid(
@@ -50,46 +75,43 @@ def grid_search_hybrid(
     tc_bps: float = 0.0,
     apply_vol_target: bool = False,
 ) -> Tuple[HybridConfig, pd.DataFrame]:
-    """Search over ``param_grid`` and return best config and results table.
-
-    Parameters
-    ----------
-    daily_prices : DataFrame
-        Daily price data used by :func:`run_hybrid_backtest`.
-    param_grid : dict
-        Mapping of ``HybridConfig`` field names to iterables of values.
-    base_cfg : HybridConfig, optional
-        Configuration to start from.  Defaults to ``HybridConfig()``.
-    tc_bps : float, optional
-        Transaction cost in basis points applied per rebalance.
-    apply_vol_target : bool, optional
-        If True and ``cfg.target_vol_annual`` is set, apply volatility targeting.
-
-    Returns
-    -------
-    best_cfg : HybridConfig
-        Configuration with the highest Sharpe ratio.
-    results : DataFrame
-        One row per parameter combination with the evaluated Sharpe ratio.
-    """
+    """Search over ``param_grid`` and return best config and results table."""
     base_cfg = base_cfg or HybridConfig()
-    keys = list(param_grid.keys())
+
+    # Only allow fields that exist on HybridConfig
+    cfg_fields = {f.name for f in fields(HybridConfig)}
+    grid = {k: list(v) for k, v in param_grid.items() if k in cfg_fields}
+    if not grid:
+        grid = {"momentum_top_n": [base_cfg.momentum_top_n], "momentum_cap": [base_cfg.momentum_cap]}
+    keys = list(grid.keys())
+
     best_score = float("-inf")
     best_cfg = base_cfg
     rows: list[dict] = []
 
-    for combo in itertools.product(*param_grid.values()):
+    # Try all combos; skip ones that error gracefully
+    for combo in itertools.product(*grid.values()):
         params = dict(zip(keys, combo))
-        cfg = replace(base_cfg, **params)
-        cfg = replace(cfg, tc_bps=tc_bps)
-        res = run_hybrid_backtest(daily_prices, cfg, apply_vol_target=apply_vol_target)
-        rets = res.get("hybrid_rets_net", res["hybrid_rets"])
-        sharpe = _annualized_sharpe(rets)
-        row = {**params, "sharpe": sharpe}
+        try:
+            cfg = replace(base_cfg, **params, tc_bps=tc_bps)
+            res = run_hybrid_backtest(daily_prices, cfg, apply_vol_target=apply_vol_target)
+            rets = res.get("hybrid_rets_net", res.get("hybrid_rets"))
+            if rets is None:
+                raise ValueError("run_hybrid_backtest returned no hybrid returns.")
+            ppyr = _infer_periods_per_year(pd.Index(rets.index))
+            sharpe = _annualized_sharpe(pd.Series(rets).dropna(), periods_per_year=ppyr)
+        except Exception as exc:
+            row = {**params, "sharpe": float("-inf"), "error": str(exc)}
+            rows.append(row)
+            continue
+
+        row = {**params, "sharpe": sharpe, "periods_per_year": ppyr}
         rows.append(row)
         if sharpe > best_score:
             best_score = sharpe
             best_cfg = cfg
 
     results = pd.DataFrame(rows)
+    if not results.empty and "sharpe" in results.columns:
+        results = results.sort_values("sharpe", ascending=False).reset_index(drop=True)
     return best_cfg, results

--- a/strategy_core.py
+++ b/strategy_core.py
@@ -467,7 +467,6 @@ def run_backtest_mean_reversion(
 
     return rets.fillna(0.0), tno.fillna(0.0)
 
-
 # ------------------------------
 # 4) Hybrid & Benchmarks
 # ------------------------------

--- a/strategy_core.py
+++ b/strategy_core.py
@@ -258,13 +258,15 @@ def run_backtest_momentum(
         scores = scores[scores > 0]
         if scores.empty:
             rets.loc[dt] = 0.0
-            tno.loc[dt] = 0.0
+            if prev_w is not None:
+                tno.loc[dt] = 0.5 * prev_w.abs().sum()
+            else:
+                tno.loc[dt] = 0.0
             prev_w = None
             continue
         top = scores.nlargest(top_n)
         raw = top / top.sum()
         w = cap_weights(raw, cap=cap)
-        w = w / w.sum()
 
         valid = w.index.intersection(future.columns)
         if get_constituents is not None:

--- a/strategy_core.py
+++ b/strategy_core.py
@@ -71,7 +71,12 @@ def get_nasdaq_100_plus_tickers(
     if date_str not in _NDX_CONSTITUENT_CACHE:
         try:
             params = {"date": date_str, "download": "true"}
-            resp = requests.get(api_url, params=params)
+            resp = requests.get(
+                api_url,
+                params=params,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=10,
+            )
             resp.raise_for_status()
             df = pd.read_csv(StringIO(resp.text))
             tickers = df["ticker"].astype(str).str.upper().str.strip().tolist()

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -10,14 +10,14 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import backend
 
 
-def test_clean_extreme_moves(monkeypatch):
+def test_clean_extreme_moves():
     messages = []
-    monkeypatch.setattr(backend.st, "info", lambda msg: messages.append(msg))
 
     idx = pd.date_range("2024-01-01", periods=5, freq="D")
     df = pd.DataFrame({"A": [1.0, 0.4, 5.0, 1.0, 1.0]}, index=idx)
     cleaned, mask = backend.clean_extreme_moves(
-        df, max_daily_move=0.30, min_price=1.0, zscore_threshold=1.0
+        df, max_daily_move=0.30, min_price=1.0, zscore_threshold=1.0,
+        info=lambda msg: messages.append(msg)
     )
 
     expected = pd.DataFrame({"A": [1.0] * 5}, index=idx)
@@ -31,16 +31,17 @@ def test_clean_extreme_moves(monkeypatch):
     assert messages == ["🧹 Data cleaning: Fixed 2 extreme price moves across all stocks"]
 
 
-def test_fill_missing_data(monkeypatch):
+def test_fill_missing_data():
     messages = []
-    monkeypatch.setattr(backend.st, "info", lambda msg: messages.append(msg))
 
     idx = pd.date_range("2024-01-01", periods=3, freq="D")
     df = pd.DataFrame({"A": [1.0, None, 3.0]}, index=idx)
 
-    filled, mask = backend.fill_missing_data(df, max_gap_days=3)
+    filled, mask = backend.fill_missing_data(
+        df, max_gap_days=3, info=lambda msg: messages.append(msg)
+    )
 
-    expected = pd.DataFrame({"A": [1.0, 1.0, 3.0]}, index=idx)
+    expected = pd.DataFrame({"A": [1.0, 2.0, 3.0]}, index=idx)
     pd.testing.assert_frame_equal(filled, expected)
 
     expected_mask = pd.DataFrame({"A": [False, True, False]}, index=idx)
@@ -49,9 +50,8 @@ def test_fill_missing_data(monkeypatch):
     assert messages == ["🔧 Data filling: Filled 1 missing data points with interpolation"]
 
 
-def test_validate_and_clean_market_data(monkeypatch):
+def test_validate_and_clean_market_data():
     messages = []
-    monkeypatch.setattr(backend.st, "info", lambda msg: messages.append(msg))
 
     idx = pd.date_range("2024-01-01", periods=5, freq="D")
     df = pd.DataFrame(
@@ -61,7 +61,9 @@ def test_validate_and_clean_market_data(monkeypatch):
         },
         index=idx,
     )
-    cleaned, alerts, mask = backend.validate_and_clean_market_data(df)
+    cleaned, alerts, mask = backend.validate_and_clean_market_data(
+        df, info=lambda msg: messages.append(msg)
+    )
 
     expected = pd.DataFrame({"A": [1.0] * 5}, index=idx)
     pd.testing.assert_frame_equal(cleaned, expected)


### PR DESCRIPTION
## Summary
- Blend risk-parity and sleeve weights without double-scaling and return residual cash for outer exposure control
- Quiet cached data cleaning by logging messages and accepting optional callbacks
- Ensure hold-branch cap enforcement uses group caps and streamline fundamental fetches

## Testing
- `PYTHONWARNINGS=ignore pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c68616c01c8327a5c1b7253ef7691e