### PR TITLE
Add volatility targeting controls to ISA backtest

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -2124,6 +2124,8 @@ def run_backtest_isa_dynamic(
     mr_weight: Optional[float] = None,
     use_enhanced_features: bool = True,
     apply_quality_filter: bool = False,
+    target_vol_annual: Optional[float] = None,
+    apply_vol_target: bool = False,
 ) -> Tuple[Optional[pd.Series], Optional[pd.Series], Optional[pd.Series], Optional[pd.Series]]:
     """
     Enhanced ISA-Dynamic hybrid backtest with new features.
@@ -2133,6 +2135,12 @@ def run_backtest_isa_dynamic(
     apply_quality_filter: bool, optional
         If True, filter the universe using *current* fundamentals. Leave False
         during historical backtests to avoid look-ahead bias.
+    target_vol_annual: float, optional
+        Annualized volatility target (e.g., 0.15 for 15%) applied when
+        ``apply_vol_target`` is True.
+    apply_vol_target: bool, optional
+        If True, scale returns using the volatility targeting helper from
+        ``strategy_core``.
     """
     if end_date is None:
         end_date = date.today().strftime("%Y-%m-%d")
@@ -2187,9 +2195,10 @@ def run_backtest_isa_dynamic(
         mr_weight=mr_weight,
         mr_lookback_days=21,
         mr_long_ma_days=200,
+        target_vol_annual=target_vol_annual if apply_vol_target else None,
     )
 
-    res = strategy_core.run_hybrid_backtest(daily, cfg)
+    res = strategy_core.run_hybrid_backtest(daily, cfg, apply_vol_target=apply_vol_target)
     hybrid_gross = res["hybrid_rets"]
     hybrid_tno = (
         cfg.mom_weight * res["mom_turnover"].reindex(hybrid_gross.index).fillna(0)

--- a/tests/test_backend_optimizer.py
+++ b/tests/test_backend_optimizer.py
@@ -36,8 +36,9 @@ def test_run_backtest_isa_dynamic_uses_optimizer(monkeypatch):
 
     import strategy_core
 
-    def fake_run_hybrid_backtest(daily_prices, cfg):
+    def fake_run_hybrid_backtest(daily_prices, cfg, apply_vol_target=False):
         captured["cfg"] = cfg
+        captured["apply_vol_target"] = apply_vol_target
         idx = pd.date_range("2020-01-31", "2020-03-31", freq="M")
         return {
             "hybrid_rets": pd.Series(0.0, index=idx),
@@ -66,3 +67,54 @@ def test_run_backtest_isa_dynamic_uses_optimizer(monkeypatch):
     assert cfg.mr_top_n == 3
     assert cfg.mom_weight == 0.6
     assert cfg.mr_weight == 0.4
+    assert captured["apply_vol_target"] is False
+    assert cfg.target_vol_annual is None
+
+
+def test_run_backtest_isa_dynamic_applies_vol_target(monkeypatch):
+    dates = pd.date_range("2020-01-01", periods=10, freq="D")
+    close = pd.DataFrame({
+        "AAA": np.linspace(100, 110, len(dates)),
+        "BBB": np.linspace(50, 60, len(dates)),
+        "QQQ": np.linspace(200, 210, len(dates)),
+    }, index=dates)
+    vol = pd.DataFrame(1.0, index=dates, columns=["AAA", "BBB", "QQQ"])
+    sectors_map = {"AAA": "Tech", "BBB": "Tech"}
+
+    def fake_prepare(universe_choice, start_date, end_date):
+        return close, vol, sectors_map, "Test"
+
+    monkeypatch.setattr(backend, "_prepare_universe_for_backtest", fake_prepare)
+
+    captured = {}
+
+    import strategy_core
+
+    def fake_run_hybrid_backtest(daily_prices, cfg, apply_vol_target=False):
+        captured["apply_vol_target"] = apply_vol_target
+        captured["target_vol"] = cfg.target_vol_annual
+        idx = pd.date_range("2020-01-31", "2020-03-31", freq="M")
+        return {
+            "hybrid_rets": pd.Series(0.0, index=idx),
+            "mom_turnover": pd.Series(0.0, index=idx),
+            "mr_turnover": pd.Series(0.0, index=idx),
+        }
+
+    monkeypatch.setattr(strategy_core, "run_hybrid_backtest", fake_run_hybrid_backtest)
+
+    backend.run_backtest_isa_dynamic(
+        min_dollar_volume=0,
+        top_n=1,
+        name_cap=1.0,
+        sector_cap=1.0,
+        stickiness_days=1,
+        mr_topn=1,
+        mom_weight=1.0,
+        mr_weight=0.0,
+        use_enhanced_features=False,
+        target_vol_annual=0.1,
+        apply_vol_target=True,
+    )
+
+    assert captured.get("apply_vol_target") is True
+    assert captured.get("target_vol") == 0.1

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -48,8 +48,9 @@ def test_run_backtest_isa_dynamic_uses_quality_filter(monkeypatch):
 
     import strategy_core
 
-    def fake_run_hybrid_backtest(daily_prices, cfg):
+    def fake_run_hybrid_backtest(daily_prices, cfg, apply_vol_target=False):
         captured["cols"] = list(daily_prices.columns)
+        captured["apply_vol_target"] = apply_vol_target
         idx = pd.date_range("2020-01-31", "2020-03-31", freq="M")
         return {
             "hybrid_rets": pd.Series(0.0, index=idx),


### PR DESCRIPTION
## Summary
- add target_vol_annual and apply_vol_target options to `run_backtest_isa_dynamic`
- forward the volatility targeting configuration to `strategy_core.run_hybrid_backtest`
- extend unit tests to cover the new parameters and updated call signatures

## Testing
- pytest *(fails: tests/test_data_cleaning.py::test_clean_extreme_moves, tests/test_data_cleaning.py::test_fill_missing_data, tests/test_data_cleaning.py::test_validate_and_clean_market_data, tests/test_parquet_caching.py::test_fetch_market_data_uses_parquet_cache)*

------
https://chatgpt.com/codex/tasks/task_e_68c9133e52008327959f66b29e63c0b4