### PR TITLE
Implement data cleaning helpers and resilient caching

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -184,11 +184,21 @@ def linear_interpolate_short_gaps(
             left = s - 1
             right = e + 1
             # Need valid endpoints on both sides to interpolate
-            if left < 0 or right >= len(series):
+            left_val = series.iat[left] if left >= 0 else np.nan
+            right_val = series.iat[right] if right < len(series) else np.nan
+
+            if left < 0 or pd.isna(left_val):
+                if pd.isna(right_val):
+                    continue
+                idx_slice = series.index[s : e + 1]
+                filled.loc[idx_slice, column] = right_val
+                imputed_mask.loc[idx_slice, column] = True
                 continue
-            left_val = series.iat[left]
-            right_val = series.iat[right]
-            if pd.isna(left_val) or pd.isna(right_val):
+
+            if right >= len(series) or pd.isna(right_val):
+                idx_slice = series.index[s : e + 1]
+                filled.loc[idx_slice, column] = left_val
+                imputed_mask.loc[idx_slice, column] = True
                 continue
 
             idx_slice = series.index[s : e + 1]
@@ -200,6 +210,147 @@ def linear_interpolate_short_gaps(
             imputed_mask.loc[idx_slice, column] = True
 
     return filled, imputed_mask
+
+
+def clean_extreme_moves(
+    prices: pd.DataFrame,
+    *,
+    max_daily_move: float = 0.35,
+    min_price: float = 0.5,
+    zscore_threshold: float | None = 4.0,
+    info: Optional[Callable[[str], None]] = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Clamp implausible price moves and return a mask of the edits made."""
+
+    if prices is None or prices.empty:
+        empty_mask = pd.DataFrame(False, index=getattr(prices, "index", []), columns=getattr(prices, "columns", []))
+        return prices.copy() if hasattr(prices, "copy") else pd.DataFrame(), empty_mask
+
+    cleaned = prices.copy()
+    mask = pd.DataFrame(False, index=cleaned.index, columns=cleaned.columns)
+
+    total_fixes = 0
+    for col in cleaned.columns:
+        col_idx = cleaned.columns.get_loc(col)
+        series = cleaned[col].astype(float)
+        returns = series.pct_change()
+        if zscore_threshold is not None:
+            std = returns.std(skipna=True)
+            if std and not np.isclose(std, 0.0):
+                zscores = (returns - returns.mean(skipna=True)) / std
+            else:
+                zscores = pd.Series(np.nan, index=returns.index)
+        else:
+            zscores = pd.Series(np.nan, index=returns.index)
+
+        for i, value in enumerate(series.values):
+            if pd.isna(value):
+                continue
+
+            prev_val = None
+            if i > 0:
+                prev_val = cleaned.iat[i - 1, col_idx]
+            flagged = False
+
+            if min_price is not None and value < min_price:
+                flagged = True
+
+            if prev_val is not None and not pd.isna(prev_val):
+                baseline = max(abs(prev_val), 1e-9)
+                if max_daily_move is not None and abs(value - prev_val) > max_daily_move * baseline:
+                    flagged = True
+                if zscore_threshold is not None:
+                    z_val = zscores.iat[i] if i < len(zscores) else np.nan
+                    if pd.notna(z_val) and abs(float(z_val)) > zscore_threshold:
+                        flagged = True
+
+            if flagged:
+                if prev_val is not None and not pd.isna(prev_val):
+                    replacement = float(prev_val)
+                elif min_price is not None:
+                    replacement = float(max(min_price, value))
+                else:
+                    replacement = float(value)
+                cleaned.iat[i, col_idx] = replacement
+                mask.iat[i, col_idx] = True
+                total_fixes += 1
+
+    if callable(info) and total_fixes > 0:
+        info(f"🧹 Data cleaning: Fixed {total_fixes} extreme price moves across all stocks")
+
+    return cleaned, mask
+
+
+def fill_missing_data(
+    prices: pd.DataFrame,
+    *,
+    max_gap_days: int = 3,
+    info: Optional[Callable[[str], None]] = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Fill short gaps via linear interpolation and return a mask of edits."""
+
+    if prices is None or prices.empty:
+        empty_mask = pd.DataFrame(False, index=getattr(prices, "index", []), columns=getattr(prices, "columns", []))
+        return prices.copy() if hasattr(prices, "copy") else pd.DataFrame(), empty_mask
+
+    filled, mask = linear_interpolate_short_gaps(prices, max_gap=max_gap_days)
+    filled_count = int(mask.to_numpy().sum())
+    if callable(info) and filled_count > 0:
+        info(f"🔧 Data filling: Filled {filled_count} missing data points with interpolation")
+    return filled, mask.astype(bool)
+
+
+def validate_and_clean_market_data(
+    prices: pd.DataFrame,
+    *,
+    max_missing_ratio: float = 0.20,
+    max_daily_move: float = 0.35,
+    min_price: float = 0.5,
+    zscore_threshold: float | None = 4.0,
+    max_gap_days: int = 3,
+    info: Optional[Callable[[str], None]] = None,
+) -> tuple[pd.DataFrame, list[str], pd.DataFrame]:
+    """Validate raw market data and apply the cleaning pipeline."""
+
+    if prices is None or prices.empty:
+        empty = pd.DataFrame(index=getattr(prices, "index", []))
+        empty_mask = pd.DataFrame(False, index=empty.index, columns=[])
+        return empty, [], empty_mask
+
+    data = prices.copy()
+    alerts: list[str] = []
+    original_shape = data.shape
+
+    if max_missing_ratio is not None and data.shape[1] > 0:
+        missing_fraction = data.isna().mean()
+        drop_cols = missing_fraction[missing_fraction > max_missing_ratio].index.tolist()
+        if drop_cols:
+            data = data.drop(columns=drop_cols)
+            threshold_pct = int(round(max_missing_ratio * 100))
+            alerts.append(f"Removed {len(drop_cols)} stocks with >{threshold_pct}% missing data")
+
+    if data.shape != original_shape:
+        alerts.append(f"Data shape: {original_shape} → {data.shape}")
+
+    if data.empty:
+        mask = pd.DataFrame(False, index=prices.index, columns=data.columns)
+        return data, alerts, mask
+
+    cleaned, mask_clean = clean_extreme_moves(
+        data,
+        max_daily_move=max_daily_move,
+        min_price=min_price,
+        zscore_threshold=zscore_threshold,
+        info=info,
+    )
+    filled, mask_fill = fill_missing_data(
+        cleaned,
+        max_gap_days=max_gap_days,
+        info=info,
+    )
+    combined_mask = (mask_clean | mask_fill).astype(bool)
+
+    return filled, alerts, combined_mask
 
 # =========================
 # NEW: Enhanced Position Sizing (Fixes the 28.99% bug)
@@ -980,6 +1131,39 @@ def _parquet_cache_path(prefix: str, tickers: List[str], start_date: str, end_da
     return PARQUET_CACHE_DIR / fname
 
 
+def _read_cached_dataframe(path: Path) -> Optional[pd.DataFrame]:
+    """Read a cached DataFrame with graceful fallback.
+
+    The primary format is parquet, but when pyarrow/fastparquet is unavailable
+    (common in lightweight test environments) we transparently fall back to
+    :func:`pandas.read_pickle`. The helper returns ``None`` if the cache is
+    missing or unreadable so callers can re-fetch the data.
+    """
+
+    if not path.exists():
+        return None
+
+    try:
+        return pd.read_parquet(path)
+    except Exception:
+        try:
+            return pd.read_pickle(path)
+        except Exception:
+            return None
+
+
+def _write_cached_dataframe(df: pd.DataFrame, path: Path) -> None:
+    """Persist ``df`` to ``path`` using parquet with pickle fallback."""
+
+    try:
+        df.to_parquet(path)
+    except Exception:
+        try:
+            df.to_pickle(path)
+        except Exception:
+            pass
+
+
 def _safe_get_info(ticker: yf.Ticker, timeout: float = 5.0) -> Dict[str, Any]:
     """Fetch ``ticker.info`` with a timeout and graceful fallback."""
 
@@ -1128,11 +1312,9 @@ def _prepare_universe_for_backtest(
 @st.cache_data(ttl=43200)
 def fetch_market_data(tickers: List[str], start_date: str, end_date: str) -> pd.DataFrame:
     cache_path = _parquet_cache_path("market", tickers, start_date, end_date)
-    if cache_path.exists():
-        try:
-            return pd.read_parquet(cache_path)
-        except Exception:
-            pass
+    cached = _read_cached_dataframe(cache_path)
+    if cached is not None:
+        return cached
 
     try:
         fetch_start = (pd.to_datetime(start_date) - pd.DateOffset(months=14)).strftime("%Y-%m-%d")
@@ -1163,16 +1345,10 @@ def fetch_market_data(tickers: List[str], start_date: str, end_date: str) -> pd.
                 for alert in cleaning_alerts[:2]:  # Show top 2 cleaning actions
                     logging.info("Data cleaning: %s", alert)
 
-            try:
-                cleaned_result.to_parquet(cache_path)
-            except Exception:
-                pass
+            _write_cached_dataframe(cleaned_result, cache_path)
             return cleaned_result
 
-        try:
-            result.to_parquet(cache_path)
-        except Exception:
-            pass
+        _write_cached_dataframe(result, cache_path)
         return result
 
     except Exception as e:
@@ -1182,19 +1358,16 @@ def fetch_market_data(tickers: List[str], start_date: str, end_date: str) -> pd.
 @st.cache_data(ttl=43200)
 def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
     cache_path = _parquet_cache_path("price_volume", tickers, start_date, end_date)
-    if cache_path.exists():
-        try:
-            combined = pd.read_parquet(cache_path)
-            if isinstance(combined.columns, pd.MultiIndex):
-                needed = {"Close", "Volume"}
-                have = set(combined.columns.get_level_values(0))
-                if needed.issubset(have):
-                    return combined["Close"], combined["Volume"]
-            else:
-                if {"Close", "Volume"}.issubset(combined.columns):
-                    return combined["Close"], combined["Volume"]
-        except Exception:
-            pass
+    combined = _read_cached_dataframe(cache_path)
+    if combined is not None:
+        if isinstance(combined.columns, pd.MultiIndex):
+            needed = {"Close", "Volume"}
+            have = set(combined.columns.get_level_values(0))
+            if needed.issubset(have):
+                return combined["Close"], combined["Volume"]
+        else:
+            if {"Close", "Volume"}.issubset(combined.columns):
+                return combined["Close"], combined["Volume"]
 
     try:
         fetch_start = (pd.to_datetime(start_date) - pd.DateOffset(months=14)).strftime("%Y-%m-%d")
@@ -1246,16 +1419,16 @@ def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tu
                 for alert in close_alerts[:1]:  # Show top cleaning action
                     logging.info("Price/Volume cleaning: %s", alert)
 
-            try:
-                pd.concat({"Close": cleaned_close, "Volume": vol_aligned}, axis=1).to_parquet(cache_path)
-            except Exception:
-                pass
+            _write_cached_dataframe(
+                pd.concat({"Close": cleaned_close, "Volume": vol_aligned}, axis=1),
+                cache_path,
+            )
             return cleaned_close, vol_aligned
 
-        try:
-            pd.concat({"Close": close, "Volume": vol}, axis=1).to_parquet(cache_path)
-        except Exception:
-            pass
+        _write_cached_dataframe(
+            pd.concat({"Close": close, "Volume": vol}, axis=1),
+            cache_path,
+        )
         return close, vol
 
     except Exception as e:
@@ -2124,6 +2297,8 @@ def run_backtest_isa_dynamic(
     mr_weight: Optional[float] = None,
     use_enhanced_features: bool = True,
     apply_quality_filter: bool = False,
+    target_vol_annual: Optional[float] = None,
+    apply_vol_target: bool = False,
 ) -> Tuple[Optional[pd.Series], Optional[pd.Series], Optional[pd.Series], Optional[pd.Series]]:
     """
     Enhanced ISA-Dynamic hybrid backtest with new features.
@@ -2133,6 +2308,12 @@ def run_backtest_isa_dynamic(
     apply_quality_filter: bool, optional
         If True, filter the universe using *current* fundamentals. Leave False
         during historical backtests to avoid look-ahead bias.
+    target_vol_annual: float, optional
+        Annualized volatility target (e.g., 0.15 for 15%) applied when
+        ``apply_vol_target`` is True.
+    apply_vol_target: bool, optional
+        If True, scale returns using the volatility targeting helper from
+        ``strategy_core``.
     """
     if end_date is None:
         end_date = date.today().strftime("%Y-%m-%d")
@@ -2187,9 +2368,10 @@ def run_backtest_isa_dynamic(
         mr_weight=mr_weight,
         mr_lookback_days=21,
         mr_long_ma_days=200,
+        target_vol_annual=target_vol_annual if apply_vol_target else None,
     )
 
-    res = strategy_core.run_hybrid_backtest(daily, cfg)
+    res = strategy_core.run_hybrid_backtest(daily, cfg, apply_vol_target=apply_vol_target)
     hybrid_gross = res["hybrid_rets"]
     hybrid_tno = (
         cfg.mom_weight * res["mom_turnover"].reindex(hybrid_gross.index).fillna(0)

--- a/tests/test_backend_optimizer.py
+++ b/tests/test_backend_optimizer.py
@@ -36,8 +36,9 @@ def test_run_backtest_isa_dynamic_uses_optimizer(monkeypatch):
 
     import strategy_core
 
-    def fake_run_hybrid_backtest(daily_prices, cfg):
+    def fake_run_hybrid_backtest(daily_prices, cfg, apply_vol_target=False):
         captured["cfg"] = cfg
+        captured["apply_vol_target"] = apply_vol_target
         idx = pd.date_range("2020-01-31", "2020-03-31", freq="M")
         return {
             "hybrid_rets": pd.Series(0.0, index=idx),
@@ -66,3 +67,54 @@ def test_run_backtest_isa_dynamic_uses_optimizer(monkeypatch):
     assert cfg.mr_top_n == 3
     assert cfg.mom_weight == 0.6
     assert cfg.mr_weight == 0.4
+    assert captured["apply_vol_target"] is False
+    assert cfg.target_vol_annual is None
+
+
+def test_run_backtest_isa_dynamic_applies_vol_target(monkeypatch):
+    dates = pd.date_range("2020-01-01", periods=10, freq="D")
+    close = pd.DataFrame({
+        "AAA": np.linspace(100, 110, len(dates)),
+        "BBB": np.linspace(50, 60, len(dates)),
+        "QQQ": np.linspace(200, 210, len(dates)),
+    }, index=dates)
+    vol = pd.DataFrame(1.0, index=dates, columns=["AAA", "BBB", "QQQ"])
+    sectors_map = {"AAA": "Tech", "BBB": "Tech"}
+
+    def fake_prepare(universe_choice, start_date, end_date):
+        return close, vol, sectors_map, "Test"
+
+    monkeypatch.setattr(backend, "_prepare_universe_for_backtest", fake_prepare)
+
+    captured = {}
+
+    import strategy_core
+
+    def fake_run_hybrid_backtest(daily_prices, cfg, apply_vol_target=False):
+        captured["apply_vol_target"] = apply_vol_target
+        captured["target_vol"] = cfg.target_vol_annual
+        idx = pd.date_range("2020-01-31", "2020-03-31", freq="M")
+        return {
+            "hybrid_rets": pd.Series(0.0, index=idx),
+            "mom_turnover": pd.Series(0.0, index=idx),
+            "mr_turnover": pd.Series(0.0, index=idx),
+        }
+
+    monkeypatch.setattr(strategy_core, "run_hybrid_backtest", fake_run_hybrid_backtest)
+
+    backend.run_backtest_isa_dynamic(
+        min_dollar_volume=0,
+        top_n=1,
+        name_cap=1.0,
+        sector_cap=1.0,
+        stickiness_days=1,
+        mr_topn=1,
+        mom_weight=1.0,
+        mr_weight=0.0,
+        use_enhanced_features=False,
+        target_vol_annual=0.1,
+        apply_vol_target=True,
+    )
+
+    assert captured.get("apply_vol_target") is True
+    assert captured.get("target_vol") == 0.1

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -48,8 +48,9 @@ def test_run_backtest_isa_dynamic_uses_quality_filter(monkeypatch):
 
     import strategy_core
 
-    def fake_run_hybrid_backtest(daily_prices, cfg):
+    def fake_run_hybrid_backtest(daily_prices, cfg, apply_vol_target=False):
         captured["cols"] = list(daily_prices.columns)
+        captured["apply_vol_target"] = apply_vol_target
         idx = pd.date_range("2020-01-31", "2020-03-31", freq="M")
         return {
             "hybrid_rets": pd.Series(0.0, index=idx),


### PR DESCRIPTION
## Summary
- add helpers to clamp extreme price moves, interpolate short gaps, and wire them into `validate_and_clean_market_data`
- teach the interpolation routine to handle edge gaps while returning edit masks for reporting
- make cached data resilient by falling back to pickle files when parquet engines are unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9133e52008327959f66b29e63c0b4