### PR TITLE
Add QQQ hedge overlay with UI telemetry

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,6 +82,7 @@ st.session_state.setdefault("max_leverage", 2.0)
 st.session_state.setdefault("show_net", True)
 st.session_state.setdefault("vix_ts_threshold", backend.VIX_TS_THRESHOLD_DEFAULT)
 st.session_state.setdefault("hy_oas_threshold", backend.HY_OAS_THRESHOLD_DEFAULT)
+st.session_state.setdefault("max_hedge", backend.HEDGE_MAX_DEFAULT)
 st.session_state["use_enhanced_features"] = use_enhanced_features
 st.session_state["auto_optimize"] = auto_optimize
 
@@ -312,6 +313,29 @@ with tab2:
         # Decision banner
         st.info(decision)
 
+        hedge_details = st.session_state.get("latest_live_hedge", {})
+        if hedge_details:
+            hedge_weight = float(hedge_details.get("weight") or 0.0)
+            corr = hedge_details.get("correlation")
+            breadth = hedge_details.get("breadth_pos_6m")
+            qqq_above = hedge_details.get("qqq_above_200dma")
+
+            help_bits = []
+            if corr is not None:
+                help_bits.append(f"Correlation vs QQQ: {corr:.2f}")
+            if qqq_above is not None:
+                help_bits.append("QQQ above 200DMA" if qqq_above >= 1 else "QQQ below 200DMA")
+            if breadth is not None and not np.isnan(breadth):
+                help_bits.append(f"Breadth (6M > 0): {breadth:.0%}")
+            help_text = "; ".join(help_bits) if help_bits else "Hedge overlay based on regime metrics."
+
+            st.metric(
+                "QQQ Hedge",
+                f"{-hedge_weight:.2%}" if hedge_weight > 0 else "0.00%",
+                delta="Active" if hedge_weight > 0 else "Inactive",
+                help=help_text,
+            )
+
         # Feature badge
         if use_enhanced_features:
             st.success("🔬 Enhanced features active: Volatility-adjusted caps, regime awareness, signal decay")
@@ -415,6 +439,29 @@ with tab3:
     if strategy_cum_gross is None or qqq_cum is None:
         st.info("Click Generate to see backtest results.")
     else:
+        hedge_details = st.session_state.get("latest_backtest_hedge", {})
+        if hedge_details:
+            hedge_weight = float(hedge_details.get("weight") or 0.0)
+            corr = hedge_details.get("correlation")
+            breadth = hedge_details.get("breadth_pos_6m")
+            qqq_above = hedge_details.get("qqq_above_200dma")
+
+            help_bits = []
+            if corr is not None:
+                help_bits.append(f"Correlation vs QQQ: {corr:.2f}")
+            if qqq_above is not None:
+                help_bits.append("QQQ above 200DMA" if qqq_above >= 1 else "QQQ below 200DMA")
+            if breadth is not None and not np.isnan(breadth):
+                help_bits.append(f"Breadth (6M > 0): {breadth:.0%}")
+            help_text = "; ".join(help_bits) if help_bits else "Hedge overlay inferred from recent regime metrics."
+
+            st.metric(
+                "Backtest QQQ Hedge",
+                f"{-hedge_weight:.2%}" if hedge_weight > 0 else "0.00%",
+                delta="Active" if hedge_weight > 0 else "Inactive",
+                help=help_text,
+            )
+
         st.markdown("#### Key Performance (monthly series inferred)")
 
         # --- KPI table ---

--- a/backend.py
+++ b/backend.py
@@ -69,6 +69,9 @@ ASSESS_LOG_FILE   = "assess_log.csv"
 ROUNDTRIP_BPS_DEFAULT   = 20
 REGIME_MA               = 200
 AVG_TRADE_SIZE_DEFAULT  = 0.02  # 2% avg single-leg trade size
+HEDGE_MAX_DEFAULT       = 0.20
+HEDGE_TICKER_LABEL      = "QQQ (Hedge)"
+HEDGE_TICKER_ALIASES    = {HEDGE_TICKER_LABEL, "QQQ_HEDGE", "QQQ-HEDGE"}
 
 # Defaults for regime-based exposure adjustments
 VIX_TS_THRESHOLD_DEFAULT = 1.0   # VIX3M / VIX ratio; <1 implies stress
@@ -122,6 +125,25 @@ def _emit_info(msg: str, info: Optional[Callable[[str], None]] = None) -> None:
 
     # 3) Fallback to logging
     logging.info(msg)
+
+
+def _record_hedge_state(scope: str,
+                        weight: float,
+                        correlation: float | None,
+                        regime_metrics: Dict[str, float]) -> None:
+    """Persist the latest hedge details for UI/reporting purposes."""
+    if not _HAS_ST:
+        return
+
+    summary = {
+        "weight": float(weight or 0.0),
+        "correlation": (None if correlation is None or pd.isna(correlation)
+                         else float(correlation)),
+        "qqq_above_200dma": regime_metrics.get("qqq_above_200dma"),
+        "breadth_pos_6m": regime_metrics.get("breadth_pos_6m"),
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    st.session_state[f"latest_{scope}_hedge"] = summary
 
 # =========================
 # NEW: Enhanced Data Validation & Cleaning
@@ -1004,6 +1026,13 @@ def get_sector_map(tickers: List[str]) -> Dict[str, str]:
     missing sector information are stored as ``"Unknown"``.
     """
 
+    tickers = list(tickers)
+
+    # Ensure the synthetic hedge ticker is always mapped without hitting yfinance
+    for alias in HEDGE_TICKER_ALIASES:
+        if alias in tickers and alias not in _SECTOR_CACHE:
+            _SECTOR_CACHE[alias] = "Hedge Overlay"
+
     new_tickers = [t for t in tickers if t not in _SECTOR_CACHE]
     for t in new_tickers:
         if t in _SECTOR_OVERRIDES:
@@ -1123,16 +1152,145 @@ def _prepare_universe_for_backtest(
     return close, vol, sectors_map, label
 
 # =========================
+# Data cleaning helpers
+# =========================
+def clean_extreme_moves(
+    prices: pd.DataFrame,
+    max_daily_move: float = 0.30,
+    min_price: float = 0.5,
+    zscore_threshold: float = 4.0,
+    info: Optional[Callable[[str], None]] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Clip extreme one-day moves and replace with adjacent prices."""
+
+    if prices.empty:
+        empty = pd.DataFrame(False, index=prices.index, columns=prices.columns)
+        return prices.copy(), empty
+
+    df = prices.copy()
+    mask = pd.DataFrame(False, index=df.index, columns=df.columns)
+
+    pct = df.pct_change().replace([np.inf, -np.inf], np.nan)
+    large_moves = pct.abs() > max_daily_move
+    low_prices = df < min_price
+    median = df.rolling(window=5, min_periods=1).median()
+    deviation = (df - median).abs() / (median.replace(0, np.nan).abs() + 1e-9)
+    extreme_price = deviation > max_daily_move
+
+    mask |= (large_moves & extreme_price).fillna(False)
+    mask |= low_prices.fillna(False)
+
+    if zscore_threshold is not None and not pct.empty:
+        zscores = (pct - pct.mean()) / (pct.std(ddof=0) + 1e-9)
+        mask |= zscores.abs() > zscore_threshold
+        mask = mask.fillna(False)
+
+    if mask.values.any():
+        cleaned = df.where(~mask)
+        filled = cleaned.ffill().bfill()
+        df = df.where(~mask, filled)
+        fixed = int(mask.values.sum())
+        msg = "🧹 Data cleaning: Fixed {} extreme price moves across all stocks".format(
+            fixed
+        )
+        _emit_info(msg, info)
+
+    return df, mask.astype(bool)
+
+
+def fill_missing_data(
+    prices: pd.DataFrame,
+    max_gap_days: int = 3,
+    info: Optional[Callable[[str], None]] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Interpolate short gaps up to ``max_gap_days`` consecutive missing points."""
+
+    if prices.empty:
+        empty = pd.DataFrame(False, index=prices.index, columns=prices.columns)
+        return prices.copy(), empty
+
+    df = prices.copy()
+    original_na = df.isna()
+
+    try:
+        filled = df.interpolate(
+            method="time",
+            limit=max_gap_days,
+            limit_direction="both",
+            limit_area="inside",
+        )
+    except Exception:
+        filled = df.interpolate(
+            method="linear",
+            limit=max_gap_days,
+            limit_direction="both",
+            limit_area="inside",
+        )
+
+    filled = filled.ffill(limit=max_gap_days).bfill(limit=max_gap_days)
+
+    mask = original_na & filled.notna()
+    filled_points = int(mask.values.sum())
+    if filled_points > 0:
+        msg = (
+            "🔧 Data filling: Filled {} missing data points with interpolation".format(
+                filled_points
+            )
+        )
+        _emit_info(msg, info)
+
+    return filled, mask.astype(bool)
+
+
+def validate_and_clean_market_data(
+    prices: pd.DataFrame,
+    max_missing_ratio: float = 0.20,
+    info: Optional[Callable[[str], None]] = None,
+) -> Tuple[pd.DataFrame, List[str], pd.DataFrame]:
+    """Run the full cleaning pipeline used by cached market data downloads."""
+
+    if prices.empty:
+        empty = pd.DataFrame(False, index=prices.index, columns=prices.columns)
+        return prices.copy(), [], empty
+
+    df = prices.copy()
+    alerts: List[str] = []
+
+    missing_ratio = df.isna().mean()
+    drop_cols = missing_ratio[missing_ratio > max_missing_ratio].index.tolist()
+    if drop_cols:
+        df = df.drop(columns=drop_cols)
+        alerts.append(
+            f"Removed {len(drop_cols)} stocks with >{int(max_missing_ratio * 100)}% missing data"
+        )
+
+    if df.empty:
+        alerts.append(f"Data shape: {prices.shape} → {df.shape}")
+        empty_mask = pd.DataFrame(False, index=df.index, columns=df.columns)
+        return df, alerts, empty_mask
+
+    cleaned, clean_mask = clean_extreme_moves(df, info=info)
+    filled, fill_mask = fill_missing_data(cleaned, info=info)
+    combined_mask = clean_mask.reindex_like(filled).fillna(False) | fill_mask
+
+    if df.shape != prices.shape or drop_cols:
+        alerts.append(f"Data shape: {prices.shape} → {filled.shape}")
+
+    return filled, alerts, combined_mask.astype(bool)
+
+
+# =========================
 # Data fetching (cache) - Enhanced with validation
 # =========================
 @st.cache_data(ttl=43200)
 def fetch_market_data(tickers: List[str], start_date: str, end_date: str) -> pd.DataFrame:
     cache_path = _parquet_cache_path("market", tickers, start_date, end_date)
     if cache_path.exists():
-        try:
-            return pd.read_parquet(cache_path)
-        except Exception:
-            pass
+        for reader in (pd.read_parquet, pd.read_pickle):
+            try:
+                return reader(cache_path)
+            except Exception:
+                continue
 
     try:
         fetch_start = (pd.to_datetime(start_date) - pd.DateOffset(months=14)).strftime("%Y-%m-%d")
@@ -1166,13 +1324,19 @@ def fetch_market_data(tickers: List[str], start_date: str, end_date: str) -> pd.
             try:
                 cleaned_result.to_parquet(cache_path)
             except Exception:
-                pass
+                try:
+                    cleaned_result.to_pickle(cache_path)
+                except Exception:
+                    pass
             return cleaned_result
 
         try:
             result.to_parquet(cache_path)
         except Exception:
-            pass
+            try:
+                result.to_pickle(cache_path)
+            except Exception:
+                pass
         return result
 
     except Exception as e:
@@ -1183,8 +1347,12 @@ def fetch_market_data(tickers: List[str], start_date: str, end_date: str) -> pd.
 def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
     cache_path = _parquet_cache_path("price_volume", tickers, start_date, end_date)
     if cache_path.exists():
-        try:
-            combined = pd.read_parquet(cache_path)
+        for reader in (pd.read_parquet, pd.read_pickle):
+            try:
+                combined = reader(cache_path)
+            except Exception:
+                continue
+
             if isinstance(combined.columns, pd.MultiIndex):
                 needed = {"Close", "Volume"}
                 have = set(combined.columns.get_level_values(0))
@@ -1193,8 +1361,6 @@ def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tu
             else:
                 if {"Close", "Volume"}.issubset(combined.columns):
                     return combined["Close"], combined["Volume"]
-        except Exception:
-            pass
 
     try:
         fetch_start = (pd.to_datetime(start_date) - pd.DateOffset(months=14)).strftime("%Y-%m-%d")
@@ -1246,16 +1412,24 @@ def fetch_price_volume(tickers: List[str], start_date: str, end_date: str) -> Tu
                 for alert in close_alerts[:1]:  # Show top cleaning action
                     logging.info("Price/Volume cleaning: %s", alert)
 
+            combined = pd.concat({"Close": cleaned_close, "Volume": vol_aligned}, axis=1)
             try:
-                pd.concat({"Close": cleaned_close, "Volume": vol_aligned}, axis=1).to_parquet(cache_path)
+                combined.to_parquet(cache_path)
             except Exception:
-                pass
+                try:
+                    combined.to_pickle(cache_path)
+                except Exception:
+                    pass
             return cleaned_close, vol_aligned
 
+        combined = pd.concat({"Close": close, "Volume": vol}, axis=1)
         try:
-            pd.concat({"Close": close, "Volume": vol}, axis=1).to_parquet(cache_path)
+            combined.to_parquet(cache_path)
         except Exception:
-            pass
+            try:
+                combined.to_pickle(cache_path)
+            except Exception:
+                pass
         return close, vol
 
     except Exception as e:
@@ -1966,6 +2140,14 @@ def generate_live_portfolio_isa_monthly(
     # Expose the price index for downstream processes (e.g. save gating)
     st.session_state["latest_price_index"] = close.index
 
+    regime_metrics: Dict[str, float] = {}
+    if len(close) > 0:
+        try:
+            regime_metrics = compute_regime_metrics(close)
+        except Exception:
+            logging.warning("R02 regime metric calculation failed in allocation", exc_info=True)
+            regime_metrics = {}
+
     # Monthly lock check – always compute new weights
     is_monthly = is_rebalance_today(today, close.index)
     decision = "Preview only – portfolio not saved" if not is_monthly else ""
@@ -1978,10 +2160,9 @@ def generate_live_portfolio_isa_monthly(
     # Apply regime-based exposure scaling to final weights
     if use_enhanced_features and len(close) > 0 and len(new_w) > 0:
         try:
-            regime_metrics = compute_regime_metrics(close)
             regime_exposure = get_regime_adjusted_exposure(regime_metrics)
             new_w = new_w * float(regime_exposure)
-        except Exception as e:
+        except Exception:
             logging.warning("R02 regime exposure scaling failed in allocation", exc_info=True)
 
     # Validate and re-enforce caps if scaling introduced violations
@@ -2015,6 +2196,32 @@ def generate_live_portfolio_isa_monthly(
                     f"Constraint violations after re-enforcing caps: {violations}"
                 )
 
+    hedge_weight = 0.0
+    corr = np.nan
+    portfolio_recent = pd.Series(dtype=float)
+    try:
+        cfg_live = HybridConfig(
+            momentum_top_n=int(params["mom_topn"]),
+            momentum_cap=float(params["mom_cap"]),
+            mr_top_n=int(params["mr_topn"]),
+            mom_weight=float(params["mom_w"]),
+            mr_weight=float(params["mr_w"]),
+            mr_lookback_days=int(params["mr_lb"]),
+            mr_long_ma_days=int(params["mr_ma"]),
+        )
+        bt_res = strategy_core.run_hybrid_backtest(close, cfg_live)
+        portfolio_recent = bt_res.get("hybrid_rets", pd.Series(dtype=float)).tail(6)
+        hedge_size = (
+            st.session_state.get("max_hedge", HEDGE_MAX_DEFAULT)
+            if _HAS_ST else HEDGE_MAX_DEFAULT
+        )
+        hedge_weight = build_hedge_weight(portfolio_recent, regime_metrics, hedge_size)
+        corr = calculate_portfolio_correlation_to_market(portfolio_recent)
+    except Exception:
+        logging.warning("H02 hedge overlay failed in allocation", exc_info=True)
+
+    final_weights = new_w.astype(float) if len(new_w) > 0 else new_w
+
     # Trigger vs previous portfolio (health of current)
     if is_monthly and prev_portfolio is not None and not prev_portfolio.empty and "Weight" in prev_portfolio.columns:
         monthly = close.resample("M").last()
@@ -2023,6 +2230,7 @@ def generate_live_portfolio_isa_monthly(
             top_m = mom_scores.nlargest(params["mom_topn"])
             top_score = float(top_m.iloc[0]) if len(top_m) > 0 else 1e-9
             prev_w = prev_portfolio["Weight"].astype(float)
+            prev_w = prev_w.drop(index=HEDGE_TICKER_LABEL, errors="ignore")
             held_scores = mom_scores.reindex(prev_w.index).fillna(0.0)
             health = float((held_scores * prev_w).sum() / max(top_score, 1e-9))
             if health >= params["trigger"]:
@@ -2041,8 +2249,7 @@ def generate_live_portfolio_isa_monthly(
                 )
                 if not violations:
                     decision = f"Health {health:.2f} ≥ trigger {params['trigger']:.2f} — holding existing portfolio."
-                    disp, raw = _format_display(prev_w)
-                    return disp, raw, decision
+                    final_weights = prev_w.astype(float)
                 decision = (
                     f"Health {health:.2f} ≥ trigger {params['trigger']:.2f}"
                     " — constraints violated, rebalancing to new targets."
@@ -2050,7 +2257,33 @@ def generate_live_portfolio_isa_monthly(
             else:
                 decision = f"Health {health:.2f} < trigger {params['trigger']:.2f} — rebalancing to new targets."
 
-    disp, raw = _format_display(new_w)
+    def _inject_hedge(weights: pd.Series) -> pd.Series:
+        w = weights.copy() if weights is not None else pd.Series(dtype=float)
+        if not isinstance(w, pd.Series):
+            w = pd.Series(dtype=float)
+        w = w.drop(index=HEDGE_TICKER_LABEL, errors="ignore")
+        if hedge_weight > 0:
+            w.loc[HEDGE_TICKER_LABEL] = -hedge_weight
+        return w.astype(float)
+
+    final_weights = _inject_hedge(final_weights if isinstance(final_weights, pd.Series) else pd.Series(dtype=float))
+
+    state = "active" if hedge_weight > 0 else "inactive"
+    corr_txt = "n/a" if pd.isna(corr) else f"{corr:.2f}"
+    _emit_info(
+        f"Live allocation QQQ hedge {state} (weight={hedge_weight:.1%}, corr={corr_txt})"
+    )
+    _record_hedge_state("live", hedge_weight, corr, regime_metrics)
+
+    hedge_note = (
+        f"QQQ hedge active at {hedge_weight:.1%} short."
+        if hedge_weight > 0
+        else "QQQ hedge inactive."
+    )
+    decision = (decision or "").strip()
+    decision = f"{decision}\n{hedge_note}" if decision else hedge_note
+
+    disp, raw = _format_display(final_weights)
     return disp, raw, decision
 
 
@@ -2196,19 +2429,51 @@ def run_backtest_isa_dynamic(
         + cfg.mr_weight * res["mr_turnover"].reindex(hybrid_gross.index).fillna(0)
     )
 
+    qqq_monthly = qqq.resample("M").last().pct_change()
+
     # Apply drawdown-based exposure adjustment (walk-forward)
     if use_enhanced_features:
-        qqq_monthly = qqq.resample("M").last().pct_change()
         hybrid_gross = apply_dynamic_drawdown_scaling(
             hybrid_gross, qqq_monthly, threshold_fraction=0.8
         )
+
+    hedge_weight = 0.0
+    corr = np.nan
+    regime_metrics: Dict[str, float] = {}
+    portfolio_recent = hybrid_gross.tail(6)
+
+    try:
+        lookback_daily = daily.iloc[-252:] if len(daily) > 252 else daily
+        if not lookback_daily.empty:
+            regime_metrics = compute_regime_metrics(lookback_daily)
+
+        hedge_size = (
+            st.session_state.get("max_hedge", HEDGE_MAX_DEFAULT)
+            if _HAS_ST else HEDGE_MAX_DEFAULT
+        )
+        hedge_weight = build_hedge_weight(portfolio_recent, regime_metrics, hedge_size)
+        corr = calculate_portfolio_correlation_to_market(portfolio_recent)
+
+        if hedge_weight > 0 and not qqq_monthly.empty:
+            qqq_aligned = qqq_monthly.reindex(hybrid_gross.index).fillna(0.0)
+            hedge_returns = -hedge_weight * qqq_aligned
+            hybrid_gross = hybrid_gross.add(hedge_returns, fill_value=0.0)
+    except Exception:
+        logging.warning("H01 hedge overlay failed in backtest", exc_info=True)
+
+    state = "active" if hedge_weight > 0 else "inactive"
+    corr_txt = "n/a" if pd.isna(corr) else f"{corr:.2f}"
+    _emit_info(
+        f"Backtest QQQ hedge {state} (weight={hedge_weight:.1%}, corr={corr_txt})"
+    )
+    _record_hedge_state("backtest", hedge_weight, corr, regime_metrics)
 
     hybrid_net = apply_costs(hybrid_gross, hybrid_tno, roundtrip_bps) if show_net else hybrid_gross
 
     # Cum curves
     strat_cum_gross = (1 + hybrid_gross.fillna(0)).cumprod()
     strat_cum_net   = (1 + hybrid_net.fillna(0)).cumprod() if show_net else None
-    qqq_cum = (1 + qqq.resample("M").last().pct_change()).cumprod().reindex(strat_cum_gross.index, method="ffill")
+    qqq_cum = (1 + qqq_monthly).cumprod().reindex(strat_cum_gross.index, method="ffill")
 
     return strat_cum_gross, strat_cum_net, qqq_cum, hybrid_tno
     

--- a/tests/test_backend_optimizer.py
+++ b/tests/test_backend_optimizer.py
@@ -54,6 +54,9 @@ def test_run_backtest_isa_dynamic_uses_optimizer(monkeypatch):
         mr_weight = 0.4
 
     monkeypatch.setattr(backend, "optimize_hybrid_strategy", lambda prices: (DummyCfg(), 0.33))
+    monkeypatch.setattr(backend, "compute_regime_metrics", lambda *args, **kwargs: {})
+    monkeypatch.setattr(backend, "build_hedge_weight", lambda *args, **kwargs: 0.0)
+    monkeypatch.setattr(backend, "calculate_portfolio_correlation_to_market", lambda *args, **kwargs: 0.0)
 
     st.session_state["min_profitability"] = 0.0
     st.session_state["max_leverage"] = 10.0

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -61,6 +61,9 @@ def test_run_backtest_isa_dynamic_uses_quality_filter(monkeypatch):
 
     st.session_state["min_profitability"] = 0.0
     st.session_state["max_leverage"] = 1.0
+    monkeypatch.setattr(backend, "compute_regime_metrics", lambda *args, **kwargs: {})
+    monkeypatch.setattr(backend, "build_hedge_weight", lambda *args, **kwargs: 0.0)
+    monkeypatch.setattr(backend, "calculate_portfolio_correlation_to_market", lambda *args, **kwargs: 0.0)
 
     backend.run_backtest_isa_dynamic(
         min_dollar_volume=0,


### PR DESCRIPTION
## Summary
- add reusable QQQ hedge constants plus helper to persist hedge diagnostics
- integrate hedge sizing into the live allocator and backtest, including UI telemetry and sector-map handling
- harden data cleaning/caching utilities and update tests to stub new hedge hooks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c913445b64832798d03d1ba4527786