### PR TITLE
Fix data cleaning helpers and guard Streamlit sidebar usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,6 +228,12 @@ if go:
                 use_enhanced_features=st.session_state.get("use_enhanced_features", True),
                 auto_optimize=auto_optimize,
             )
+            if strategy_cum_gross is not None:
+                st.session_state["strategy_cum_gross"] = strategy_cum_gross
+            if strategy_cum_net is not None:
+                st.session_state["strategy_cum_net"] = strategy_cum_net
+            if qqq_cum is not None:
+                st.session_state["qqq_cum"] = qqq_cum
             if auto_cfg is not None:
                 st.session_state["auto_best_config"] = asdict(auto_cfg)
             if auto_diag is not None and not auto_diag.empty:

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -37,7 +37,7 @@ def test_fill_missing_data():
     idx = pd.date_range("2024-01-01", periods=3, freq="D")
     df = pd.DataFrame({"A": [1.0, None, 3.0]}, index=idx)
 
-    filled, fill_mask, cap_mask = backend.fill_missing_data(
+    filled, fill_mask = backend.fill_missing_data(
         df, max_gap_days=3, info=lambda msg: messages.append(msg)
     )
 
@@ -46,9 +46,6 @@ def test_fill_missing_data():
 
     expected_mask = pd.DataFrame({"A": [False, True, False]}, index=idx)
     pd.testing.assert_frame_equal(fill_mask, expected_mask)
-
-    expected_cap_mask = pd.DataFrame({"A": [False, False, False]}, index=idx)
-    pd.testing.assert_frame_equal(cap_mask, expected_cap_mask)
 
     assert messages == ["🔧 Data filling: Filled 1 missing data points with interpolation"]
 
@@ -64,22 +61,22 @@ def test_validate_and_clean_market_data():
         },
         index=idx,
     )
-    cleaned, alerts, fill_mask, cap_mask = backend.validate_and_clean_market_data(
+    cleaned, alerts, cap_mask, interp_mask = backend.validate_and_clean_market_data(
         df, info=lambda msg: messages.append(msg)
     )
 
     expected = pd.DataFrame({"A": [1.0, 1.0, 1.3, 1.0, 1.0]}, index=idx)
     pd.testing.assert_frame_equal(cleaned, expected)
 
-    expected_fill_mask = pd.DataFrame(
-        {"A": [False, False, False, False, True]}, index=idx
-    )
-    pd.testing.assert_frame_equal(fill_mask, expected_fill_mask)
-
     expected_cap_mask = pd.DataFrame(
         {"A": [False, False, True, False, False]}, index=idx
     )
     pd.testing.assert_frame_equal(cap_mask, expected_cap_mask)
+
+    expected_interp_mask = pd.DataFrame(
+        {"A": [False, False, False, False, True]}, index=idx
+    )
+    pd.testing.assert_frame_equal(interp_mask, expected_interp_mask)
 
     assert alerts == [
         "Removed 1 stocks with >20% missing data",


### PR DESCRIPTION
## Summary
- standardize the data cleaning helpers to return consistent masks and remove duplicate definitions
- guard Streamlit sidebar notifications with logging fallbacks and fix the live portfolio decision overwrite
- align the backtest API and app session state handling with the expanded return payload and update the data cleaning tests

## Testing
- `pytest tests/test_data_cleaning.py`
- `pytest tests/test_rebalance_monthly_lock.py`
- `pytest tests/test_live_portfolio_caps.py`
- `pytest tests/test_post_scaling_constraint.py`
- `pytest tests/test_backend_optimizer.py`
- `pytest tests/test_parquet_caching.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9435a04f4832792c03c8005ad297f