### PR TITLE
Enable configurable parallelism for hybrid optimizer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 streamlit>=1.35
 pandas>=2.2
 numpy>=1.26
+joblib>=1.3
 yfinance>=0.2.40
 matplotlib>=3.8
 requests>=2.32


### PR DESCRIPTION
## Summary
- add a joblib-backed grid search implementation with a safe fallback and support for `n_jobs`
- allow `optimize_hybrid_strategy` and `run_backtest_isa_dynamic` to accept an optional worker count and propagate it to the optimizer
- expose the joblib dependency so environments can install it

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c951cf313c8327992421966cabfb0e