### PR TITLE
Fix base cumulative lookup in trust checks

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -4542,7 +4542,9 @@ def run_trust_checks(
 
     # 3) Health (use the same series you show in Performance tab)
     # Pull what the app saved in session
-    base_cum = st.session_state.get("strategy_cum_net") or st.session_state.get("strategy_cum_gross")
+    base_cum = st.session_state.get("strategy_cum_net")
+    if base_cum is None:
+        base_cum = st.session_state.get("strategy_cum_gross")
     qqq_cum  = st.session_state.get("qqq_cum")
 
     def _to_monthly(series):


### PR DESCRIPTION
## Summary
- update the trust checks helper to avoid truthiness when selecting the base cumulative return series
- rely on the existing monthly conversion helper to handle missing cumulative data cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97c6c85708327b95b06cbe1356fe4