### PR TITLE
Tighten constraint tolerance and test borderline scaling

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -3135,8 +3135,10 @@ def check_constraint_violations(
     violations = []
     
     # Check name caps
+    tol = 1e-6
+
     for ticker, weight in weights.items():
-        if weight > name_cap + 0.01:  # 1% tolerance
+        if weight > name_cap + tol:
             violations.append(f"{ticker}: {weight:.1%} > {name_cap:.1%}")
     
     # Check sector caps
@@ -3144,7 +3146,7 @@ def check_constraint_violations(
     sector_sums = weights.groupby(sectors).sum()
 
     for sector, total_weight in sector_sums.items():
-        if total_weight > sector_cap + 0.01:  # 1% tolerance
+        if total_weight > sector_cap + tol:
             violations.append(f"{sector}: {total_weight:.1%} > {sector_cap:.1%}")
 
     # Optional hierarchical/group caps (e.g., Software sub-buckets)
@@ -3160,7 +3162,7 @@ def check_constraint_violations(
                 w = group_sums.get(group, 0.0)
             else:
                 w = parent_sums.get(group, 0.0)
-            if w > cap + 0.01:  # 1% tolerance
+            if w > cap + tol:
                 violations.append(f"{group}: {w:.1%} > {cap:.1%}")
     
     return violations

--- a/tests/test_post_scaling_constraint.py
+++ b/tests/test_post_scaling_constraint.py
@@ -11,11 +11,18 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import backend
 
 
-def _mock_env(monkeypatch):
+def _mock_env(
+    monkeypatch,
+    base_weights: dict[str, float] | None = None,
+    exposure: float = 2.0,
+    sector_map: dict[str, str] | None = None,
+):
+    base_weights = base_weights or {"AAA": 0.25, "BBB": 0.25}
+    sector_map = sector_map or {"AAA": "Tech", "BBB": "Tech"}
+
     def fake_get_universe(choice):
-        tickers = ["AAA", "BBB"]
-        sectors = {"AAA": "Tech", "BBB": "Tech"}
-        return tickers, sectors, "Label"
+        tickers = list(base_weights.keys())
+        return tickers, sector_map, "Label"
 
     def fake_fetch_price_volume(tickers, start, end):
         idx = pd.date_range("2024-06-01", periods=10, freq="B")
@@ -31,7 +38,7 @@ def _mock_env(monkeypatch):
 
     def fake_build_weights(close, params, sectors_map, use_enhanced_features=True):
         # already respecting caps before scaling
-        return pd.Series({"AAA": 0.25, "BBB": 0.25})
+        return pd.Series(base_weights)
 
     monkeypatch.setattr(backend, "get_universe", fake_get_universe)
     monkeypatch.setattr(backend, "fetch_price_volume", fake_fetch_price_volume)
@@ -39,7 +46,7 @@ def _mock_env(monkeypatch):
     monkeypatch.setattr(backend, "fundamental_quality_filter", fake_fundamental_quality_filter)
     monkeypatch.setattr(backend, "_build_isa_weights_fixed", fake_build_weights)
     monkeypatch.setattr(backend, "compute_regime_metrics", lambda hist: {})
-    monkeypatch.setattr(backend, "get_regime_adjusted_exposure", lambda metrics: 2.0)
+    monkeypatch.setattr(backend, "get_regime_adjusted_exposure", lambda metrics: exposure)
     monkeypatch.setattr(backend, "is_rebalance_today", lambda today, idx: True)
 
 
@@ -63,6 +70,32 @@ def test_scaling_enforces_caps(monkeypatch):
     assert calls["count"] == 1
     assert raw["Weight"].max() <= preset["mom_cap"] + 1e-9
     assert raw["Weight"].sum() <= preset["sector_cap"] + 1e-9
+
+
+def test_borderline_scaling_triggers_reenforcement(monkeypatch):
+    _mock_env(
+        monkeypatch,
+        base_weights={"AAA": 0.25, "BBB": 0.25},
+        exposure=1.0005,
+        sector_map={"AAA": "Tech", "BBB": "Health"},
+    )
+
+    calls = {"count": 0}
+    orig_enforce = backend.enforce_caps_iteratively
+
+    def tracking_enforce(*args, **kwargs):
+        calls["count"] += 1
+        return orig_enforce(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "enforce_caps_iteratively", tracking_enforce)
+
+    preset = backend.STRATEGY_PRESETS["ISA Dynamic (0.75)"]
+    disp, raw, decision = backend.generate_live_portfolio_isa_monthly(
+        preset, None, as_of=date(2024, 6, 3)
+    )
+
+    assert calls["count"] == 1
+    assert raw["Weight"].max() <= preset["mom_cap"] + 1e-9
 
 
 def test_scaling_raises_on_unfixed(monkeypatch):


### PR DESCRIPTION
## Summary
- reduce the tolerance used by `check_constraint_violations` so small overruns are flagged
- enhance the post-scaling constraint tests with configurable mocks and a borderline scaling scenario

## Testing
- pytest tests/test_post_scaling_constraint.py

------
https://chatgpt.com/codex/tasks/task_e_68da5f69b6208327a57175cc43791b95