### PR TITLE
Sanitize universes and harden Yahoo downloads

### DIFF
--- a/tests/test_constituent_membership.py
+++ b/tests/test_constituent_membership.py
@@ -43,5 +43,5 @@ def test_constituent_cache(monkeypatch):
     monkeypatch.setattr(sc.requests, "get", fake_get)
     first = sc.get_nasdaq_100_plus_tickers(as_of="2024-01-01")
     second = sc.get_nasdaq_100_plus_tickers(as_of="2024-01-01")
-    assert first == second == ["AAPL", "MSFT"]
+    assert first == second == ["AAPL", "MSFT", "QQQ"]
     assert len(calls) == 1


### PR DESCRIPTION
## Summary
- sanitize NASDAQ-derived universes and append QQQ so hedging/regime logic always has a benchmark
- harden Yahoo download helpers to skip bad tickers, retry smaller batches, and backfill missing QQQ prices/volume
- update the constituent cache test to expect the benchmark in the sanitized output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da60679f248327a3df3ec87d001786