### PR TITLE
Ensure live portfolio stays populated and add diagnostics

### DIFF
--- a/app.py
+++ b/app.py
@@ -405,6 +405,11 @@ with tab2:
 
         st.dataframe(live_disp, use_container_width=True)
 
+        dbg = st.session_state.get("eligibility_debug", [])
+        if dbg:
+            st.caption("Eligibility pipeline (count after each gate):")
+            st.table(pd.DataFrame(dbg, columns=["Stage", "Count"]))
+
         # Extract current weights safely
         try:
             if "Weight" in live_raw.columns:


### PR DESCRIPTION
## Summary
- add eligibility-stage diagnostics plus adaptive gating so the live allocator never returns an empty universe
- harden momentum and mean-reversion sleeves with safe weight generation and post-cap rescaling to preserve equity exposure
- guard explainability price selection and surface eligibility counts in the UI for easier debugging

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd058d411883279879a204e2d1fbd6