### PR TITLE
Fix hedge correlation fallback and diversify safety nets

### DIFF
--- a/tests/test_backtest_standardization.py
+++ b/tests/test_backtest_standardization.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pandas as pd
+import streamlit as st
+import types
+
+# Provide empty secrets so backend import does not fail
+st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
+
+import backend
+
+
+def test_standardize_backtest_payload_handles_pandas_objects():
+    idx = pd.date_range("2023-01-31", periods=3, freq="M")
+    series = pd.Series([0.01, np.nan, 0.03], index=idx, name="ret")
+    frame = pd.DataFrame({"a": [1.0, np.nan, 3.0]}, index=idx)
+
+    payload = backend.standardize_backtest_payload(
+        {
+            "series": series,
+            "frame": frame,
+            "empty": pd.Series(dtype=float),
+            "scalar": np.float64(1.25),
+        }
+    )
+
+    ser_payload = payload["series"]
+    assert ser_payload["type"] == "series"
+    assert ser_payload["name"] == "ret"
+    assert ser_payload["values"][1] is None
+    assert ser_payload["index"][0].startswith("2023-01")
+
+    frame_payload = payload["frame"]
+    assert frame_payload["type"] == "dataframe"
+    assert frame_payload["columns"] == ["a"]
+    assert frame_payload["data"][1][0] is None
+
+    empty_payload = payload["empty"]
+    assert empty_payload["values"] == []
+
+    assert payload["scalar"] == 1.25

--- a/tests/test_diversification_safety_net.py
+++ b/tests/test_diversification_safety_net.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pandas as pd
+import streamlit as st
+import types
+
+# Provide empty secrets so backend import does not fail
+st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
+
+import backend
+
+
+def _dummy_prices(columns):
+    idx = pd.date_range("2023-01-01", periods=3, freq="B")
+    data = np.tile(np.arange(1, len(idx) + 1), (len(columns), 1)).T
+    return pd.DataFrame(data, index=idx, columns=columns)
+
+
+def test_diversification_safety_net_targets_minimum_breadth():
+    base_names = [f"T{i}" for i in range(8)]
+    weights = pd.Series([0.125] * len(base_names), index=base_names, dtype=float)
+    extras = pd.Series(
+        np.linspace(1.0, 0.2, 7),
+        index=[f"X{i}" for i in range(7)],
+    )
+    prices = _dummy_prices(base_names + ["QQQ"])
+
+    adjusted, applied, notes = backend.apply_diversification_safety_net(
+        weights,
+        extras,
+        prices,
+        min_names=10,
+        fallback_min_names=15,
+    )
+
+    assert applied is True
+    assert adjusted[adjusted > 0].shape[0] >= 15
+    assert "secondary_pool" in notes
+
+
+def test_diversification_safety_net_uses_etf_overlay_when_needed():
+    base_names = [f"Z{i}" for i in range(8)]
+    weights = pd.Series([0.125] * len(base_names), index=base_names, dtype=float)
+    extras = pd.Series([1.0, 0.8], index=["Y1", "Y2"])
+    prices = _dummy_prices(base_names + ["QQQ"])
+
+    adjusted, applied, notes = backend.apply_diversification_safety_net(
+        weights,
+        extras,
+        prices,
+        min_names=10,
+        fallback_min_names=15,
+    )
+
+    assert applied is True
+    assert "etf_overlay" in notes
+    assert "QQQ" in adjusted.index

--- a/tests/test_portfolio_correlation.py
+++ b/tests/test_portfolio_correlation.py
@@ -27,3 +27,18 @@ def test_calculate_portfolio_correlation_resamples_to_monthly():
     corr = backend.calculate_portfolio_correlation_to_market(portfolio_returns, market_returns)
 
     assert corr == pytest.approx(expected_corr)
+
+
+def test_calculate_portfolio_correlation_fallback_metadata():
+    idx = pd.date_range("2023-01-31", periods=2, freq="M")
+    portfolio_returns = pd.Series([0.01, -0.02], index=idx)
+
+    corr, meta = backend.calculate_portfolio_correlation_to_market(
+        portfolio_returns,
+        portfolio_returns,
+        return_metadata=True,
+    )
+
+    assert corr == 0.0
+    assert meta["fallback"] is True
+    assert meta["points"] <= 2


### PR DESCRIPTION
## Summary
- add a standardization helper for backtest artefacts to avoid ambiguous Series truth checks and cache the normalized payload in session state
- harden hedge correlation handling by aligning to portfolio data, defaulting NaN correlations to zero with warnings, and surfacing fallback context in hedge summaries
- tighten diversification safety net thresholds so secondary picks and ETF overlays top up thin portfolios, with new unit tests covering the behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd337138b48327b7fe7a679c505bf1