### PR TITLE
Unify backtest payload handling and improve hedge diagnostics

### DIFF
--- a/tests/test_backtest_standardization.py
+++ b/tests/test_backtest_standardization.py
@@ -1,40 +1,56 @@
 import numpy as np
 import pandas as pd
+import pytest
 import streamlit as st
 import types
+import sys
+import pathlib
 
 # Provide empty secrets so backend import does not fail
 st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
 
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import backend
 
 
-def test_standardize_backtest_payload_handles_pandas_objects():
-    idx = pd.date_range("2023-01-31", periods=3, freq="M")
-    series = pd.Series([0.01, np.nan, 0.03], index=idx, name="ret")
-    frame = pd.DataFrame({"a": [1.0, np.nan, 3.0]}, index=idx)
+def test_standardize_backtest_payload_creates_canonical_curves():
+    idx = pd.date_range("2020-01-31", periods=4, freq="ME")
+    gross = pd.Series([1.0, 1.05, 1.02, 1.08], index=idx)
+    net = pd.Series([1.0, 1.04, 1.01, 1.06], index=idx)
+    bench = pd.Series([1.0, 1.02, 0.99, 1.05], index=idx)
+    turnover = pd.Series([0.2, 0.15, np.nan, 0.25], index=idx)
 
     payload = backend.standardize_backtest_payload(
-        {
-            "series": series,
-            "frame": frame,
-            "empty": pd.Series(dtype=float),
-            "scalar": np.float64(1.25),
-        }
+        strategy_cum_gross=gross,
+        strategy_cum_net=net,
+        qqq_cum=bench,
+        hybrid_tno=turnover,
+        show_net=True,
     )
 
-    ser_payload = payload["series"]
-    assert ser_payload["type"] == "series"
-    assert ser_payload["name"] == "ret"
-    assert ser_payload["values"][1] is None
-    assert ser_payload["index"][0].startswith("2023-01")
+    equity_strategy = backend.deserialize_backtest_series(payload["equity_strategy"])
+    assert np.allclose(equity_strategy.values, net.dropna().values)
 
-    frame_payload = payload["frame"]
-    assert frame_payload["type"] == "dataframe"
-    assert frame_payload["columns"] == ["a"]
-    assert frame_payload["data"][1][0] is None
+    rets_strategy = backend.deserialize_backtest_series(payload["rets_strategy"])
+    expected = net.pct_change().dropna()
+    assert np.allclose(rets_strategy.values, expected.values)
 
-    empty_payload = payload["empty"]
-    assert empty_payload["values"] == []
+    rets_bench = backend.deserialize_backtest_series(payload["rets_bench"])
+    assert np.allclose(rets_bench.values, bench.pct_change().dropna().values)
 
-    assert payload["scalar"] == 1.25
+    turnover_payload = backend.deserialize_backtest_series(payload["turnover"])
+    assert np.allclose(turnover_payload.values, turnover.dropna().values)
+
+
+def test_compute_hedge_metadata_enforces_overlap():
+    idx = pd.date_range("2021-01-31", periods=12, freq="ME")
+    portfolio = pd.Series(np.linspace(0.01, 0.12, 12), index=idx)
+    bench = portfolio.copy()
+
+    meta = backend.compute_hedge_metadata(portfolio, bench, min_overlap=12)
+    assert meta["overlap"] == 12
+    assert meta["correlation"] == pytest.approx(1.0)
+
+    short_meta = backend.compute_hedge_metadata(portfolio.head(6), bench.head(6), min_overlap=12)
+    assert short_meta["correlation"] is None
+    assert short_meta["overlap"] == 6


### PR DESCRIPTION
## Summary
- convert `standardize_backtest_payload` into a canonical JSON-safe builder and expose helpers for round-tripping series
- align automatic backtest storage, hedge metadata, and trust checks to the canonical payload
- refresh Streamlit tabs to consume the canonical artefacts, clean rebalance plan buys, and clarify hedge correlation messaging

## Testing
- pytest tests/test_backtest_standardization.py


------
https://chatgpt.com/codex/tasks/task_e_68dd4437d0a483279d987923bc1196fb