### PR TITLE
Fix regime scoring and add guardrail tests

### DIFF
--- a/tests/test_market_conditions.py
+++ b/tests/test_market_conditions.py
@@ -41,9 +41,10 @@ def test_assess_market_conditions_risk_on(monkeypatch):
     metrics = {
         "breadth_pos_6m": 0.7,
         "qqq_vol_10d": 0.02,
-        "vix_term_structure": 1.1,
+        "vix_term_structure": 0.95,
         "hy_oas": 4.0,
         "qqq_above_200dma": 1.0,
+        "universe_above_200dma": 0.75,
     }
     _base_patch(monkeypatch, metrics, "Risk-On", eligible_count=120)
     result = backend.assess_market_conditions(date(2024, 1, 5))
@@ -59,9 +60,10 @@ def test_assess_market_conditions_risk_off(monkeypatch):
     metrics = {
         "breadth_pos_6m": 0.3,
         "qqq_vol_10d": 0.05,
-        "vix_term_structure": 0.8,
+        "vix_term_structure": 1.4,
         "hy_oas": 7.0,
         "qqq_above_200dma": 0.0,
+        "universe_above_200dma": 0.2,
     }
     _base_patch(monkeypatch, metrics, "Risk-Off", eligible_count=40)
     result = backend.assess_market_conditions(date(2024, 1, 5))
@@ -77,9 +79,10 @@ def test_assess_market_conditions_logs(monkeypatch):
     metrics = {
         "breadth_pos_6m": 0.7,
         "qqq_vol_10d": 0.02,
-        "vix_term_structure": 1.1,
+        "vix_term_structure": 0.95,
         "hy_oas": 4.0,
         "qqq_above_200dma": 1.0,
+        "universe_above_200dma": 0.75,
     }
     _base_patch(monkeypatch, metrics, "Risk-On")
 

--- a/tests/test_regime_label.py
+++ b/tests/test_regime_label.py
@@ -1,0 +1,73 @@
+import math
+import pathlib
+import sys
+import types
+
+import numpy as np
+import streamlit as st
+
+st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import backend
+
+
+def test_compute_regime_label_bearish_risk_off():
+    metrics = {
+        "qqq_above_200dma": 0,
+        "breadth_pos_6m": 0.0,
+        "vix_term_structure": 1.4,
+        "qqq_vol_10d": 0.04,
+        "universe_above_200dma": 0.1,
+    }
+
+    label, score, components = backend.compute_regime_label(metrics)
+
+    assert label == "Risk-Off"
+    assert score <= 33.0
+    assert components["vix_ts"] < 10
+
+
+def test_compute_regime_label_blocks_impossible_risk_on():
+    metrics = {
+        "qqq_above_200dma": 0,
+        "breadth_pos_6m": 0.03,
+        "vix_term_structure": 1.3,
+        "qqq_vol_10d": np.nan,
+        "qqq_50dma_slope_10d": 0.05,
+        "universe_above_200dma": 0.2,
+    }
+
+    label, score, _ = backend.compute_regime_label(metrics)
+
+    assert label != "Risk-On"
+    assert score <= 55.0
+
+
+def test_compute_regime_label_nan_volatility_neutral():
+    metrics = {
+        "qqq_above_200dma": 1,
+        "breadth_pos_6m": 0.5,
+        "vix_term_structure": 1.0,
+        "qqq_vol_10d": np.nan,
+        "universe_above_200dma": 0.5,
+    }
+
+    _, _, components = backend.compute_regime_label(metrics)
+
+    assert math.isclose(components["volatility"], 50.0, abs_tol=1e-6)
+
+
+def test_compute_regime_label_vix_directionality():
+    base = {
+        "qqq_above_200dma": 1,
+        "breadth_pos_6m": 0.5,
+        "qqq_vol_10d": 0.02,
+        "universe_above_200dma": 0.5,
+    }
+
+    _, _, comps_low = backend.compute_regime_label({**base, "vix_term_structure": 0.9})
+    _, _, comps_high = backend.compute_regime_label({**base, "vix_term_structure": 1.1})
+
+    assert comps_low["vix_ts"] > comps_high["vix_ts"]


### PR DESCRIPTION
## Summary
- replace the regime scoring logic with a unified `compute_regime_label` helper that inverts VIX term structure, clamps NaNs to neutral, and applies guardrails against impossible Risk-On states
- update `assess_market_conditions` and related helpers to consume the new scoring outputs and adjust risk-on/off universe and cap logic accordingly
- add focused tests covering bearish overrides, VIX directionality, and NaN volatility handling

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd4af7d3c88327963faec6fb29c121