### PR TITLE
Ensure fallback breadth, correlation safety, and benchmark harness

### DIFF
--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Benchmark harness for Hybrid150 strategy variants."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from dataclasses import dataclass
+from datetime import date
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+import pandas as pd
+
+import backend
+
+
+@dataclass
+class ScenarioResult:
+    name: str
+    equity_gross: pd.Series
+    equity_net: pd.Series
+    benchmark: pd.Series
+    turnover: pd.Series
+    returns: pd.Series
+    benchmark_returns: pd.Series
+    payload: Dict[str, object]
+    regime_timeline: pd.DataFrame
+
+
+def _annualize_return(returns: pd.Series) -> float:
+    if returns.empty:
+        return float("nan")
+    compounded = (1 + returns).prod()
+    periods = returns.shape[0]
+    years = periods / 12.0
+    if years <= 0:
+        return float("nan")
+    return float(compounded ** (1 / years) - 1)
+
+
+def _annualized_vol(returns: pd.Series) -> float:
+    if returns.empty:
+        return float("nan")
+    return float(returns.std(ddof=0) * math.sqrt(12))
+
+
+def _sortino_ratio(returns: pd.Series) -> float:
+    if returns.empty:
+        return float("nan")
+    downside = returns[returns < 0]
+    if downside.empty:
+        return float("inf")
+    downside_vol = downside.std(ddof=0) * math.sqrt(12)
+    if downside_vol == 0:
+        return float("inf")
+    annual_ret = returns.mean() * 12
+    return float(annual_ret / downside_vol)
+
+
+def _max_drawdown(equity: pd.Series) -> float:
+    if equity.empty:
+        return float("nan")
+    running_max = equity.cummax()
+    dd = equity / running_max - 1
+    return float(dd.min())
+
+
+def _calmar(cagr: float, max_dd: float) -> float:
+    if math.isnan(cagr) or math.isnan(max_dd) or max_dd == 0:
+        return float("nan")
+    return float(cagr / abs(max_dd))
+
+
+def _hit_rate(returns: pd.Series) -> float:
+    if returns.empty:
+        return float("nan")
+    return float((returns > 0).mean())
+
+
+def _avg_trades_per_year(turnover: pd.Series) -> float:
+    if turnover.empty:
+        return float("nan")
+    avg_monthly = float(turnover.mean())
+    return float((avg_monthly * 12) / backend.AVG_TRADE_SIZE_DEFAULT)
+
+
+def _ensure_directory(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def _canonical_payload(
+    gross: pd.Series,
+    net: pd.Series,
+    bench: pd.Series,
+    turnover: pd.Series,
+    show_net: bool = True,
+) -> Dict[str, object]:
+    return backend.standardize_backtest_payload(
+        strategy_cum_gross=gross,
+        strategy_cum_net=net,
+        qqq_cum=bench,
+        hybrid_tno=turnover,
+        show_net=show_net,
+    )
+
+
+def _regime_timeline(daily_prices: pd.DataFrame, months: Iterable[pd.Timestamp]) -> pd.DataFrame:
+    records: List[Dict[str, object]] = []
+    for ts in months:
+        window = daily_prices.loc[:ts].tail(252)
+        if window.empty or len(window) < 60:
+            continue
+        metrics = backend.compute_regime_metrics(window)
+        label, score, comps = backend.compute_regime_label(metrics)
+        records.append(
+            {
+                "date": ts,
+                "regime": label,
+                "regime_score": score,
+            }
+        )
+    if not records:
+        return pd.DataFrame(columns=["regime", "regime_score"])
+    df = pd.DataFrame(records).drop_duplicates(subset=["date"], keep="last")
+    df = df.sort_values("date").set_index("date")
+    return df
+
+
+def _bucket_label(label: str) -> str:
+    norm = (label or "").lower()
+    if "extreme" in norm:
+        return "Extreme Risk-Off"
+    if "risk-off" in norm:
+        return "Risk-Off"
+    if "risk-on" in norm:
+        return "Risk-On"
+    return "Neutral"
+
+
+def _regime_metrics(returns: pd.Series, timeline: pd.DataFrame) -> Dict[str, Dict[str, float]]:
+    if returns.empty or timeline.empty:
+        return {}
+    joined = timeline.reindex(returns.index, method="ffill").dropna()
+    out: Dict[str, Dict[str, float]] = {}
+    for bucket in {"Risk-On", "Neutral", "Risk-Off", "Extreme Risk-Off"}:
+        mask = joined["regime"].apply(_bucket_label) == bucket
+        if not mask.any():
+            continue
+        bucket_rets = returns.loc[mask.index[mask]]
+        metrics = {
+            "cagr": _annualize_return(bucket_rets),
+            "vol": _annualized_vol(bucket_rets),
+        }
+        vol = metrics["vol"]
+        ann_ret = bucket_rets.mean() * 12 if not bucket_rets.empty else float("nan")
+        metrics["sharpe"] = float(ann_ret / vol) if vol and not math.isnan(vol) and vol != 0 else float("nan")
+        metrics["max_drawdown"] = _max_drawdown((1 + bucket_rets).cumprod())
+        metrics["hit_rate"] = _hit_rate(bucket_rets)
+        out[bucket] = metrics
+    return out
+
+
+def _run_backtest_scenario(
+    name: str,
+    start: str,
+    end: str,
+    universe: str,
+    roundtrip_bps: float,
+    min_dollar_volume: float,
+    use_enhanced_features: bool = True,
+) -> ScenarioResult:
+    strat_cum_gross, strat_cum_net, qqq_cum, turnover, _, _ = backend.run_backtest_isa_dynamic(
+        roundtrip_bps=roundtrip_bps,
+        min_dollar_volume=min_dollar_volume,
+        show_net=True,
+        start_date=start,
+        end_date=end,
+        universe_choice=universe,
+        use_enhanced_features=use_enhanced_features,
+        auto_optimize=False,
+    )
+    if strat_cum_net is None or qqq_cum is None:
+        raise RuntimeError(f"Scenario {name} failed to produce equity curves")
+
+    gross = pd.Series(strat_cum_gross).astype(float) if strat_cum_gross is not None else pd.Series(dtype=float)
+    net = pd.Series(strat_cum_net).astype(float)
+    bench = pd.Series(qqq_cum).astype(float)
+    tno = pd.Series(turnover).astype(float) if turnover is not None else pd.Series(dtype=float)
+    returns = net.pct_change().dropna()
+    bench_returns = bench.pct_change().dropna()
+
+    close, _, _, _ = backend._prepare_universe_for_backtest(universe, start, end)
+    timeline = _regime_timeline(close, net.index)
+
+    payload = _canonical_payload(gross, net, bench, tno, show_net=True)
+
+    return ScenarioResult(
+        name=name,
+        equity_gross=gross,
+        equity_net=net,
+        benchmark=bench,
+        turnover=tno,
+        returns=returns,
+        benchmark_returns=bench_returns,
+        payload=payload,
+        regime_timeline=timeline,
+    )
+
+
+def _run_leadership_scenario(start: str, end: str) -> ScenarioResult:
+    tickers = list(dict.fromkeys(
+        backend.FALLBACK_BROAD_ETFS + backend.FALLBACK_SECTOR_ETFS + [backend.FALLBACK_CORE_TICKER]
+    ))
+    daily = backend.fetch_market_data(tickers, start, end)
+    daily = backend._ensure_unique_sorted_index(daily)
+    if daily.empty:
+        raise RuntimeError("Leadership ETF data unavailable")
+
+    monthly = daily.resample("M").last().dropna(how="all")
+    monthly_returns = monthly.pct_change().dropna(how="all")
+
+    weights_by_month: Dict[pd.Timestamp, pd.Series] = {}
+    equity = [1.0]
+    dates: List[pd.Timestamp] = []
+    returns: List[float] = []
+
+    for ts in monthly_returns.index:
+        window = daily.loc[:ts].tail(252)
+        metrics = backend.compute_regime_metrics(window) if not window.empty else {}
+        weights, _, target, _, _ = backend.compose_graceful_fallback(
+            stock_weights=None,
+            regime_metrics=metrics,
+            regime_label=metrics.get("regime"),
+            base_target=0.8,
+            min_names=backend.MIN_ELIGIBLE_FALLBACK,
+            eligible_pool=0,
+            leadership_slice=backend.LEADERSHIP_SLICE_DEFAULT,
+            core_slice=backend.CORE_SPY_SLICE_DEFAULT,
+        )
+        aligned = monthly_returns.loc[ts].reindex(weights.index).fillna(0.0)
+        ret = float((weights * aligned).sum())
+        weights_by_month[ts] = weights
+        equity.append(equity[-1] * (1 + ret))
+        dates.append(ts)
+        returns.append(ret)
+
+    equity_series = pd.Series(equity[1:], index=pd.Index(dates, name="date"))
+    net = equity_series
+    gross = net.copy()
+    bench = monthly.loc[net.index, "QQQ"].pct_change().add(1).cumprod() if "QQQ" in monthly.columns else net
+    turnover = pd.Series(0.0, index=net.index)
+    rets = pd.Series(returns, index=net.index)
+    bench_rets = bench.pct_change().dropna()
+
+    timeline = _regime_timeline(daily, net.index)
+    payload = _canonical_payload(gross, net, bench, turnover, show_net=True)
+
+    return ScenarioResult(
+        name="Leadership_ETF_Blend",
+        equity_gross=gross,
+        equity_net=net,
+        benchmark=bench,
+        turnover=turnover,
+        returns=rets,
+        benchmark_returns=bench_rets,
+        payload=payload,
+        regime_timeline=timeline,
+    )
+
+
+def _scenario_metrics(result: ScenarioResult) -> Dict[str, object]:
+    cagr = _annualize_return(result.returns)
+    vol = _annualized_vol(result.returns)
+    sharpe = float((result.returns.mean() * 12) / vol) if vol and not math.isnan(vol) and vol != 0 else float("nan")
+    sortino = _sortino_ratio(result.returns)
+    max_dd = _max_drawdown(result.equity_net)
+    calmar = _calmar(cagr, max_dd)
+    hit_rate = _hit_rate(result.returns)
+    avg_trades = _avg_trades_per_year(result.turnover)
+    regimes = _regime_metrics(result.returns, result.regime_timeline)
+
+    return {
+        "CAGR": cagr,
+        "Vol": vol,
+        "Sharpe": sharpe,
+        "Sortino": sortino,
+        "Calmar": calmar,
+        "MaxDD": max_dd,
+        "MAR": calmar,
+        "HitRate": hit_rate,
+        "AvgTradesPerYear": avg_trades,
+        "CashUtilization": None,
+        "HedgeUtilization": None,
+        "Regimes": regimes,
+    }
+
+
+def run_benchmarks(start: str, end: str, export: str, universe_choice: str) -> None:
+    roundtrip_bps = backend.ROUNDTRIP_BPS_DEFAULT
+    min_dollar_volume = 0.0
+
+    if universe_choice.lower() == "locked":
+        base_universe = "Hybrid Top150"
+    else:
+        base_universe = universe_choice
+
+    scenarios: List[ScenarioResult] = []
+    scenarios.append(
+        _run_backtest_scenario(
+            "Hybrid150",
+            start,
+            end,
+            base_universe,
+            roundtrip_bps,
+            min_dollar_volume,
+        )
+    )
+    scenarios.append(
+        _run_backtest_scenario(
+            "SP500_Fallback",
+            start,
+            end,
+            "S&P500 (All)",
+            roundtrip_bps,
+            min_dollar_volume,
+        )
+    )
+    scenarios.append(_run_leadership_scenario(start, end))
+
+    metrics: Dict[str, Dict[str, object]] = {}
+    equity_rows: List[Dict[str, object]] = []
+    turnover_rows: List[Dict[str, object]] = []
+    regime_rows: List[Dict[str, object]] = []
+    payloads: Dict[str, Dict[str, object]] = {}
+
+    for result in scenarios:
+        metrics[result.name] = _scenario_metrics(result)
+        payloads[result.name] = result.payload
+        for ts, value in result.equity_net.items():
+            equity_rows.append(
+                {
+                    "date": ts.isoformat(),
+                    "scenario": result.name,
+                    "equity_net": float(value),
+                    "equity_gross": float(result.equity_gross.get(ts, value)),
+                    "benchmark": float(result.benchmark.get(ts, np.nan)),
+                }
+            )
+        for ts, value in result.turnover.items():
+            turnover_rows.append(
+                {
+                    "date": ts.isoformat(),
+                    "scenario": result.name,
+                    "turnover": float(value),
+                }
+            )
+        if not result.regime_timeline.empty:
+            for ts, row in result.regime_timeline.iterrows():
+                regime_rows.append(
+                    {
+                        "date": ts.isoformat(),
+                        "scenario": result.name,
+                        "regime": row.get("regime"),
+                        "regime_score": float(row.get("regime_score", np.nan)),
+                    }
+                )
+
+    _ensure_directory(export)
+
+    metrics_path = os.path.join(export, "metrics.json")
+    equity_path = os.path.join(export, "equity_curves.csv")
+    turnover_path = os.path.join(export, "turnover.csv")
+    regime_path = os.path.join(export, "regime_timeline.csv")
+    payload_path = os.path.join(export, "payload.json")
+
+    with open(metrics_path, "w", encoding="utf-8") as fh:
+        json.dump({"scenarios": metrics}, fh, indent=2, default=float)
+
+    pd.DataFrame(equity_rows).to_csv(equity_path, index=False)
+    pd.DataFrame(turnover_rows).to_csv(turnover_path, index=False)
+    pd.DataFrame(regime_rows).to_csv(regime_path, index=False)
+
+    with open(payload_path, "w", encoding="utf-8") as fh:
+        json.dump(payloads, fh, indent=2, default=float)
+
+    print(f"Metrics written to {metrics_path}")
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    today = date.today().strftime("%Y-%m-%d")
+    parser = argparse.ArgumentParser(description="Run Hybrid150 benchmark scenarios")
+    parser.add_argument("--start", default="2017-07-01", help="Backtest start date (YYYY-MM-DD)")
+    parser.add_argument("--end", default=today, help="Backtest end date (YYYY-MM-DD or 'today')")
+    parser.add_argument("--export", default="out", help="Directory for exported artefacts")
+    parser.add_argument("--universe", default="locked", help="Universe selection (locked/Hybrid Top150/etc)")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = _parse_args(argv)
+    end = args.end
+    if end.lower() == "today":
+        end = date.today().strftime("%Y-%m-%d")
+    run_benchmarks(args.start, end, args.export, args.universe)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -1,0 +1,87 @@
+import json
+import pathlib
+import sys
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+import streamlit as st
+
+st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+import backend  # noqa: E402
+from scripts import run_benchmarks  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _patch_backend(monkeypatch):
+    index = pd.date_range("2020-01-31", periods=6, freq="M")
+    equity = pd.Series(np.linspace(1.0, 1.6, len(index)), index=index)
+    bench = pd.Series(np.linspace(1.0, 1.4, len(index)), index=index)
+    turnover = pd.Series(0.5, index=index)
+
+    def fake_run_backtest(**kwargs):
+        return equity, equity, bench, turnover, None, pd.DataFrame()
+
+    daily_index = pd.date_range("2020-01-01", "2020-06-30", freq="B")
+    daily_prices = pd.DataFrame({"AAA": np.linspace(10, 15, len(daily_index)), "QQQ": np.linspace(50, 55, len(daily_index))}, index=daily_index)
+
+    def fake_prepare(universe, start, end):
+        return daily_prices, None, {}, universe
+
+    monthly_prices = daily_prices.resample("M").last()
+
+    def fake_fetch(tickers, start, end):
+        cols = {t: np.linspace(10 + i, 12 + i, len(daily_index)) for i, t in enumerate(tickers)}
+        return pd.DataFrame(cols, index=daily_index)
+
+    def fake_metrics(window):
+        return {"regime_score": 60.0, "regime": "Risk-On"}
+
+    def fake_label(metrics):
+        return metrics.get("regime", "Neutral"), metrics.get("regime_score", 50.0), {}
+
+    def fake_fallback(**kwargs):
+        weights = pd.Series(1.0 / len(backend.FALLBACK_BROAD_ETFS), index=backend.FALLBACK_BROAD_ETFS)
+        return (
+            weights,
+            True,
+            0.8,
+            0.2,
+            {
+                "components": list(weights.index),
+                "candidate_pool": list(weights.index),
+                "equity_target": 0.8,
+                "added": list(weights.index),
+            },
+        )
+
+    monkeypatch.setattr(backend, "run_backtest_isa_dynamic", lambda **kwargs: fake_run_backtest())
+    monkeypatch.setattr(backend, "_prepare_universe_for_backtest", lambda *args, **kwargs: fake_prepare(*args, **kwargs))
+    monkeypatch.setattr(backend, "fetch_market_data", lambda *args, **kwargs: fake_fetch(*args, **kwargs))
+    monkeypatch.setattr(backend, "compute_regime_metrics", lambda *args, **kwargs: fake_metrics(*args, **kwargs))
+    monkeypatch.setattr(backend, "compute_regime_label", lambda metrics: fake_label(metrics))
+    monkeypatch.setattr(backend, "compose_graceful_fallback", lambda *args, **kwargs: fake_fallback(**kwargs))
+
+    yield
+
+
+def test_run_benchmarks_outputs(tmp_path):
+    out_dir = tmp_path / "artifacts"
+    run_benchmarks.run_benchmarks("2020-01-01", "2020-06-30", str(out_dir), "Hybrid Top150")
+
+    metrics_path = out_dir / "metrics.json"
+    equity_path = out_dir / "equity_curves.csv"
+    payload_path = out_dir / "payload.json"
+
+    assert metrics_path.exists()
+    assert equity_path.exists()
+    assert payload_path.exists()
+
+    data = json.loads(metrics_path.read_text())
+    assert "scenarios" in data
+    assert set(data["scenarios"].keys()) == {"Hybrid150", "SP500_Fallback", "Leadership_ETF_Blend"}

--- a/tests/test_equity_target_curve.py
+++ b/tests/test_equity_target_curve.py
@@ -1,0 +1,28 @@
+import pathlib
+import sys
+import types
+
+import streamlit as st
+
+st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import backend  # noqa: E402
+
+
+def test_equity_target_extends_above_one():
+    metrics = {"regime_score": 95.0}
+    target = backend._determine_equity_target("Risk-On", metrics, base_target=0.9)
+    assert 1.05 <= target <= 1.10
+
+
+def test_equity_target_clamps_in_risk_off():
+    metrics = {"regime_score": 15.0}
+    target = backend._determine_equity_target("Extreme Risk-Off", metrics, base_target=0.6)
+    assert target <= 0.35
+
+
+def test_equity_target_neutral_band():
+    metrics = {"regime_score": 55.0}
+    target = backend._determine_equity_target("Neutral", metrics, base_target=0.7)
+    assert 0.60 <= target <= 0.90

--- a/tests/test_fallback_blend.py
+++ b/tests/test_fallback_blend.py
@@ -1,0 +1,50 @@
+import pathlib
+import sys
+import types
+
+import pandas as pd
+import pytest
+import streamlit as st
+
+st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import backend  # noqa: E402
+
+
+def test_fallback_blend_meets_min_positions_and_caps():
+    blended, used, target, cash_weight, meta = backend.compose_graceful_fallback(
+        stock_weights=pd.Series(dtype=float),
+        regime_metrics={"regime_score": 60.0, "qqq_above_200dma": 0.4},
+        regime_label="Neutral",
+        base_target=0.8,
+        min_names=backend.MIN_ELIGIBLE_FALLBACK,
+        eligible_pool=0,
+        leadership_slice=backend.LEADERSHIP_SLICE_DEFAULT,
+        core_slice=backend.CORE_SPY_SLICE_DEFAULT,
+    )
+
+    assert used is True
+    assert len(blended[blended > 0]) >= backend.MIN_ELIGIBLE_FALLBACK
+    assert float(blended.max()) <= 0.10 + 1e-6
+    assert cash_weight >= 0.0
+
+
+def test_fallback_cap_relaxes_when_target_low():
+    blended, used, target, cash_weight, meta = backend.compose_graceful_fallback(
+        stock_weights=pd.Series(dtype=float),
+        regime_metrics={"regime_score": 20.0, "qqq_above_200dma": 0.2},
+        regime_label="Risk-Off",
+        base_target=0.4,
+        min_names=backend.MIN_ELIGIBLE_FALLBACK,
+        eligible_pool=0,
+        leadership_slice=backend.LEADERSHIP_SLICE_DEFAULT,
+        core_slice=backend.CORE_SPY_SLICE_DEFAULT,
+    )
+
+    assert used is True
+    assert target <= 0.5
+    assert len(blended[blended > 0]) >= backend.MIN_ELIGIBLE_FALLBACK
+    assert float(blended.max()) <= 0.20 + 1e-6
+    assert cash_weight >= 0.0
+    assert meta["components"]

--- a/tests/test_portfolio_correlation.py
+++ b/tests/test_portfolio_correlation.py
@@ -1,8 +1,11 @@
+import pathlib
+import sys
+import types
+
 import numpy as np
 import pandas as pd
 import pytest
 import streamlit as st
-import sys, pathlib, types
 
 # Provide empty secrets so backend import does not fail
 st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
@@ -13,7 +16,7 @@ import backend
 
 def test_calculate_portfolio_correlation_resamples_to_monthly():
     # Three months of daily returns
-    index = pd.date_range("2023-01-01", periods=90, freq="D")
+    index = pd.date_range("2023-01-01", periods=220, freq="D")
     rng = np.random.default_rng(seed=42)
     market_daily = rng.normal(0.001, 0.01, len(index))
     portfolio_daily = market_daily + rng.normal(0, 0.005, len(index))
@@ -39,6 +42,7 @@ def test_calculate_portfolio_correlation_fallback_metadata():
         return_metadata=True,
     )
 
-    assert corr == 0.0
+    assert corr is None
     assert meta["fallback"] is True
     assert meta["points"] <= 2
+    assert meta["status"] == "insufficient_data"

--- a/tests/test_safe_corr.py
+++ b/tests/test_safe_corr.py
@@ -1,0 +1,45 @@
+import pathlib
+import sys
+import types
+
+import pandas as pd
+import pytest
+import streamlit as st
+
+st.secrets = types.SimpleNamespace(get=lambda *args, **kwargs: None)
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import backend  # noqa: E402
+
+
+def test_correlation_none_when_overlap_short():
+    idx = pd.date_range("2023-01-31", periods=5, freq="M")
+    portfolio = pd.Series([0.01, 0.02, -0.01, 0.0, 0.005], index=idx)
+    market = pd.Series([0.015, 0.018, -0.005, 0.002, 0.004], index=idx)
+
+    corr, meta = backend.calculate_portfolio_correlation_to_market(
+        portfolio,
+        market,
+        return_metadata=True,
+    )
+
+    assert corr is None
+    assert meta["fallback"] is True
+    assert meta["status"] == "insufficient_data"
+    assert meta["points"] == 5
+
+
+def test_correlation_none_when_series_degenerate():
+    idx = pd.date_range("2022-01-31", periods=6, freq="M")
+    portfolio = pd.Series([0.0] * 6, index=idx)
+    market = pd.Series([0.01, 0.02, -0.01, 0.0, 0.005, -0.002], index=idx)
+
+    corr, meta = backend.calculate_portfolio_correlation_to_market(
+        portfolio,
+        market,
+        return_metadata=True,
+    )
+
+    assert corr is None
+    assert meta["status"] == "degenerate_series"
+    assert meta["fallback"] is True


### PR DESCRIPTION
## Summary
- expand the leadership ETF roster, add minimum-position padding, and clamp regime-driven equity targets within the 0.10–1.10 band so fallback portfolios stay diversified while honoring risk-off caps
- enrich correlation handling to return `None` with explicit status metadata when overlap is short or variance collapses, keeping hedge notices and UI displays aligned
- add a reusable `scripts/run_benchmarks.py` harness that exports metrics, equity curves, turnover, regime timelines, and canonical payload snapshots for Hybrid150, S&P 500 fallback, and leadership ETF blend scenarios
- extend unit coverage for fallback breadth, equity-target curve, safe correlation, and the benchmark CLI

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd5ef85c0c8327802821e330c01ca6